### PR TITLE
Added error handling for API key at start up 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,12 @@ import FerryTempo from './FerryTempo.js';
 const hostname = '127.0.0.1';
 const port = process.env.port || 8080;
 
+//verify that the API Key is defined before starting up
+const key = `${process.env.WSDOT_API_KEY}`;
+if ((key == undefined) || (key == "undefined") || (key == null)) {
+  console.error("API key is not defined. Make sure you have WSDOT_API_KEY defined in your .env file.");
+  process.exit(-1);
+}
 // Start the WSDOT vessel data fetching loop.
 WSDOT.startFetchInterval();
 

--- a/src/WSDOT.js
+++ b/src/WSDOT.js
@@ -21,15 +21,27 @@ export default {
   },
 
   fetchVesselData: function() {
+    var status;
     fetch(`https://www.wsdot.wa.gov/ferries/api/vessels/rest/vessellocations?apiaccesscode=${process.env.WSDOT_API_KEY}`)
-        .then((res) => res.json())
+        .then((res) =>  {
+          status = res.status;
+          return res.json()
+        })
         .then((json) => {
           console.log('Retrieved WSDOT data.');
-          // Store the received WSDOT vessel data
-          this.setVesselData(json);
 
-          // Process the WSDOT vessel data into FerryTempo
-          FerryTempo.processFerryData(this.getVesselData());
+          // if the response status is not 200, we ran into an error
+          if( status != 200 ) {
+            console.error("Error retrieving data from WSDOT site");
+            console.error(json);
+          } else {
+
+            // Store the received WSDOT vessel data
+            this.setVesselData(json);
+
+            // Process the WSDOT vessel data into FerryTempo
+            FerryTempo.processFerryData(this.getVesselData());
+          }
         });
   },
 


### PR DESCRIPTION
Added error handling to check for the API key at startup to avoid an otherwise obscure error message at failed startup. In addition, added error handling that checks the status code returned from the WSDOT website to only process requests that receive a status code of "200" (OK success). Tested by renaming my .env file to effectively remove it and verified the error handling is correct. Then restored the file to confirm that the error handling doesn't block normal behavior.

This PR resolves #34