### PR TITLE
54 port arrival time minus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -104,6 +104,18 @@ export default {
           logger.debug('BoatEta (' + epochEta + ') is in the past (' + VesselName + ') at (' + getCurrentEpochSeconds() + '): ' + getHumanDateFromEpochSeconds(epochEta));
         }
 
+        // Calculate the BoatETA as a function of the progress we have made on the journey
+        let calcEta = 0;
+        if (InService && !AtDock && epochEta != 0 && arrivalTimeEta != 0) {
+          calcEta = Math.trunc((epochEta - getEpochSecondsFromWSDOT(LeftDock)) * (1.0 - getProgress(routeData, currentLocation)) );
+          //logger.debug('Route [' + DepartingTerminalAbbrev + '-' + ArrivingTerminalAbbrev + '] Delta between reported ETA (' + arrivalTimeEta + ') and boat ETA (' + calcEta + ') is: ' + (arrivalTimeEta - calcEta));
+        }
+
+        // Logging ETA as a function of route and boat
+        if (InService && !AtDock && epochEta != 0) {
+          logger.debug('[' + DepartingTerminalAbbrev + '-' + ArrivingTerminalAbbrev + ']; ' + VesselName + ' ETA: ' + (epochEta - getEpochSecondsFromWSDOT(LeftDock)));
+        }
+
         // Set boatData.
         targetRoute['boatData'][`boat${VesselPositionNum}`] = {
           'ArrivingTerminalAbbrev': ArrivingTerminalAbbrev,

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -94,18 +94,13 @@ export default {
           boatDelay = epochTimeStamp - epochScheduledDeparture;
         }
 
-        // The Eta should be set if the boat is in service and has left the dock. 
-        if(InService && !AtDock && !Eta) {
-          logger.debug('Eta unset for boat (' + VesselName + ') with progress: ' + getProgress(routeData, currentLocation));
-        }
-
         // Calculate BoatETA as the diference (in seconds) between the ETA provied and now
         let arrivalTimeEta = 0;
         if (epochEta != 0 && epochEta > getCurrentEpochSeconds()) {
           arrivalTimeEta = epochEta - getCurrentEpochSeconds();
         } else if (epochEta != 0) {
-          // typically the epochEta is 0 when the ETA is null from WSDOT, which occurs when the boat is at dock, so we skip that
-          //and only adjust the ETA if the value is incorrect.
+          // ETA is negative typically when the boat is late arriving since the ETA doesn't get recalculated by WSDOT.
+          // When we see this, we will return 0 but log it for debugging purposes. 
           logger.debug('BoatEta (' + epochEta + ') is in the past (' + VesselName + ') at (' + getCurrentEpochSeconds() + '): ' + getHumanDateFromEpochSeconds(epochEta));
         }
 

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -67,8 +67,9 @@ export default {
         let arrivingPort;
         let routeData;
         let direction;
-        // Determine departing port (portES vs portWN), route data, and direction.
-        // RoutePositionData is stored in "West to East" order.
+        /** Determine departing port (portES vs portWN), route data, and direction.
+          * RoutePositionData is stored in "West to East" order.
+          * */
         if (routeFTData[routeAbbreviation]['portData']['portES']['TerminalID'] == DepartingTerminalID) {
           targetRoute = updatedFerryTempoData[routeAbbreviation];
           departingPort = 'portES';
@@ -97,7 +98,6 @@ export default {
         /** Calculate the BoatETA as a function of the progress we have made on the journey. We use this value unless we do not get
         *   a departureTime value from WSDOT for the boat, in wich case we will use the arrivalTimeEta computed from the Eta field and now().
         **/
-        // a departureTime value from WSDOT for the boat, in wich case we will use the arrivalTimeEta computed from the Eta field and now().
         let arrivalTimeEta = 0;
         if (InService && !AtDock && epochEta != 0 ) {
           let departureTime = getEpochSecondsFromWSDOT(LeftDock);
@@ -107,8 +107,9 @@ export default {
             if (epochEta > getCurrentEpochSeconds()) {
               arrivalTimeEta = epochEta - getCurrentEpochSeconds();
             } else if (epochEta != 0) {
-              // ETA is negative typically when the boat is late arriving since the ETA doesn't get recalculated by WSDOT.
-              // When we see this, we will use the value 0 but log it for debugging purposes. 
+              /** ETA is negative typically when the boat is late arriving since the ETA doesn't get recalculated by WSDOT.
+                * When we see this, we will use the value 0 but log it for debugging purposes. 
+                */
               logger.debug('BoatEta (' + epochEta + ') is in the past (' + VesselName + ') at (' + getCurrentEpochSeconds() + '): ' + getHumanDateFromEpochSeconds(epochEta));
             }
           }

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -94,14 +94,19 @@ export default {
           boatDelay = epochTimeStamp - epochScheduledDeparture;
         }
 
-        // Calculate BoatETA as the diference between the ETA provied and now
+        // The Eta should be set if the boat is in service and has left the dock. 
+        if(InService && !AtDock && !Eta) {
+          logger.debug('Eta unset for boat (' + VesselName + ') with progress: ' + getProgress(routeData, currentLocation));
+        }
+
+        // Calculate BoatETA as the diference (in seconds) between the ETA provied and now
         let arrivalTimeEta = 0;
         if (epochEta != 0 && epochEta > getCurrentEpochSeconds()) {
           arrivalTimeEta = epochEta - getCurrentEpochSeconds();
         } else if (epochEta != 0) {
           // typically the epochEta is 0 when the ETA is null from WSDOT, which occurs when the boat is at dock, so we skip that
           //and only adjust the ETA if the value is incorrect.
-          logger.debug('BoatEta is in the past: ' + getHumanDateFromEpochSeconds(epochEta));
+          logger.debug('BoatEta (' + epochEta + ') is in the past (' + VesselName + ') at (' + getCurrentEpochSeconds() + '): ' + getHumanDateFromEpochSeconds(epochEta));
         }
 
         // Set boatData.

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -100,20 +100,15 @@ export default {
           arrivalTimeEta = epochEta - getCurrentEpochSeconds();
         } else if (epochEta != 0) {
           // ETA is negative typically when the boat is late arriving since the ETA doesn't get recalculated by WSDOT.
-          // When we see this, we will return 0 but log it for debugging purposes. 
+          // When we see this, we will use the value 0 but log it for debugging purposes. 
           logger.debug('BoatEta (' + epochEta + ') is in the past (' + VesselName + ') at (' + getCurrentEpochSeconds() + '): ' + getHumanDateFromEpochSeconds(epochEta));
         }
 
-        // Calculate the BoatETA as a function of the progress we have made on the journey
-        let calcEta = 0;
-        if (InService && !AtDock && epochEta != 0 && arrivalTimeEta != 0) {
-          calcEta = Math.trunc((epochEta - getEpochSecondsFromWSDOT(LeftDock)) * (1.0 - getProgress(routeData, currentLocation)) );
-          //logger.debug('Route [' + DepartingTerminalAbbrev + '-' + ArrivingTerminalAbbrev + '] Delta between reported ETA (' + arrivalTimeEta + ') and boat ETA (' + calcEta + ') is: ' + (arrivalTimeEta - calcEta));
-        }
-
-        // Logging ETA as a function of route and boat
-        if (InService && !AtDock && epochEta != 0) {
-          logger.debug('[' + DepartingTerminalAbbrev + '-' + ArrivingTerminalAbbrev + ']; ' + VesselName + ' ETA: ' + (epochEta - getEpochSecondsFromWSDOT(LeftDock)));
+        // Calculate the BoatETA as a function of the progress we have made on the journey. We use this value unless we do not get
+        // a departureTime value from WSDOT for the boat, in wich case we will use the arrivalTimeEta computed above.
+        let departureTime = getEpochSecondsFromWSDOT(LeftDock);
+        if (InService && !AtDock && epochEta != 0 && departureTime != 0) {
+          arrivalTimeEta = Math.trunc((epochEta - departureTime) * (1.0 - getProgress(routeData, currentLocation)));
         }
 
         // Set boatData.

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -136,7 +136,7 @@ export default {
         };
 
         // Set portData.
-        targetRoute['portData'][departingPort].BoatAtDock = DepartingTerminalAbbrev && AtDock && InService;
+        targetRoute['portData'][departingPort].BoatAtDock = AtDock && InService;
         targetRoute['portData'][arrivingPort].PortArrivalTimeMinus = arrivalTimeEta;
         targetRoute['portData'][arrivingPort].PortETA = epochEta;
       }

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -94,7 +94,9 @@ export default {
           boatDelay = epochTimeStamp - epochScheduledDeparture;
         }
 
-        // Calculate the BoatETA as a function of the progress we have made on the journey. We use this value unless we do not get
+        /** Calculate the BoatETA as a function of the progress we have made on the journey. We use this value unless we do not get
+        *   a departureTime value from WSDOT for the boat, in wich case we will use the arrivalTimeEta computed from the Eta field and now().
+        **/
         // a departureTime value from WSDOT for the boat, in wich case we will use the arrivalTimeEta computed from the Eta field and now().
         let arrivalTimeEta = 0;
         if (InService && !AtDock && epochEta != 0 ) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -23,6 +23,10 @@ class Logger {
     });
   }
 
+  debug(message) {
+    this.logger.log('debug', message);
+  }
+
   info(message) {
     this.logger.log('info', message);
   }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -51,7 +51,7 @@ export function getCurrentEpochSeconds() {
 }
 
 /** 
- * Return the proived epoch time value into a string date for use in logging and debugging
+ * Return the prvided epoch time value into a string date for use in logging and debugging
  * @return {string} The input epoch time converted to human readable format
  */
 export function getHumanDateFromEpochSeconds(epochSec) {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -56,7 +56,8 @@ export function getCurrentEpochSeconds() {
  */
 export function getHumanDateFromEpochSeconds(epochSec) {
   function pad(n) {return n<10 ? '0'+n : n}
-  let d = new Date(epochSec);
+  let epochTime = epochSec * 1000;
+  let d = new Date(epochTime);
   let dash = '-';
   let colon = ':';
   return d.getFullYear() + dash +

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -55,7 +55,13 @@ export function getCurrentEpochSeconds() {
  * @return {string} The input epoch time converted to human readable format
  */
 export function getHumanDateFromEpochSeconds(epochSec) {
+  /**
+   * Pad a single digit by adding a leading zero where needed ('1' to be '01') for use in printing dates
+   * @param {*} number 
+   * @returns string with the input number padded to a width of 2
+   */
   function pad(n) {return n<10 ? '0'+n : n}
+  
   let epochTime = epochSec * 1000;
   let d = new Date(epochTime);
   let dash = '-';

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -50,6 +50,23 @@ export function getCurrentEpochSeconds() {
   return Math.floor(Date.now() / 1000);
 }
 
+/** 
+ * Return the proived epoch time value into a string date for use in logging and debugging
+ * @return {string} The input epoch time converted to human readable format
+ */
+export function getHumanDateFromEpochSeconds(epochSec) {
+  function pad(n) {return n<10 ? '0'+n : n}
+  let d = new Date(epochSec);
+  let dash = '-';
+  let colon = ':';
+  return d.getFullYear() + dash +
+  pad(d.getMonth()+1) + dash +
+  pad(d.getDate()) + ' ' +
+  pad(d.getHours()) + colon +
+  pad(d.getMinutes()) + colon +
+  pad(d.getSeconds());
+}
+
 /**
  * Calculates the percentage of progress along a route for a given location.
  *

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -51,7 +51,7 @@ export function getCurrentEpochSeconds() {
 }
 
 /** 
- * Return the prvided epoch time value into a string date for use in logging and debugging
+ * Return the provided epoch time value into a string for use in logging and debugging
  * @return {string} The input epoch time converted to human readable format
  */
 export function getHumanDateFromEpochSeconds(epochSec) {

--- a/test/Logger.test.js
+++ b/test/Logger.test.js
@@ -12,6 +12,13 @@ describe('Logger', () => {
     jest.clearAllMocks();
   });
 
+  test('debug method logs message with level "debug"', () => {
+    const spy = jest.spyOn(logger.logger, 'log');
+    const message = 'This is a debug message';
+    logger.debug(message);
+    expect(spy).toHaveBeenCalledWith('debug', message);
+  });
+
   test('info method logs message with level "info"', () => {
     const spy = jest.spyOn(logger.logger, 'log');
     const message = 'This is an info message';

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -72,7 +72,8 @@ describe('getHumanDateFromEpochSeconds function', () => {
   test('should return the actual epoch', () => {
     expect(getHumanDateFromEpochSeconds(0)).toBe('1969-12-31 16:00:00');
   });
-  test('should return the date May 7, 2024 at 5:51', () => {
+  // this test not only checks a certain date/time but also verifies pad() works
+  test('should return the date May 7, 2024 at 10:51:00', () => {
     expect(getHumanDateFromEpochSeconds(1715104260)).toBe('2024-05-07 10:51:00');
   });
 });

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -4,6 +4,7 @@ import {
   getCurrentEpochSeconds,
   getProgress,
   calculateDistance,
+  getHumanDateFromEpochSeconds,
 } from '../src/Utils.js';
 
 describe('getSecondsFromNow function', () => {
@@ -64,5 +65,14 @@ describe('calculateDistance function', () => {
     const coord2 = [34.0522, -118.2437]; // Los Angeles, CA
     // Calculated distance between San Francisco and Los Angeles is approximately 559.7 km
     expect(calculateDistance(coord1, coord2)).toBeCloseTo(559.1, 1);
+  });
+});
+
+describe('getHumanDateFromEpochSeconds function', () => {
+  test('should return the actual epoch', () => {
+    expect(getHumanDateFromEpochSeconds(0)).toBe('1969-12-31 16:00:00');
+  });
+  test('should return the date May 7, 2024 at 5:51', () => {
+    expect(getHumanDateFromEpochSeconds(1715104260)).toBe('2024-05-07 10:51:00');
   });
 });


### PR DESCRIPTION
Added processing for the arrival time ETA, which is calculated as the number of seconds remaining until the boat is predicted to get to dock. WSDOT sometime returns ETAs in the past, when the boat is running late because the ETA value is not recalculated during the voyage. We just set this to zero to avoid thrashing the results as it gets to dock. The ETA can also be slow to getting set when a boat departs, in this case the ETA from WSDOT is null which results in us setting the ETA to zero until we get a result. 

I also missed a logging entry in FerryTempo.js, which is fixed here in this pull request.

Addresses issue number 54.