### PR TITLE
Fixed the wait departure delay is computed and add value to port data

### DIFF
--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -89,10 +89,14 @@ export default {
           continue;
         }
 
-        // Determine BoatDepartureDelay.
+        // Determine BoatDepartureDelay, which is either (epochLeftDock - epochScheduledDeparture) or (now - epochScheduledDeparture) when in dock
         let boatDelay = 0;
-        if (epochScheduledDeparture && epochTimeStamp && (epochTimeStamp > epochScheduledDeparture)) {
-          boatDelay = epochTimeStamp - epochScheduledDeparture;
+        if (epochLeftDock && epochScheduledDeparture) {
+          boatDelay = epochLeftDock - epochScheduledDeparture;
+        } else {
+          if (epochScheduledDeparture && epochTimeStamp && (epochTimeStamp > epochScheduledDeparture)) {
+            boatDelay = epochTimeStamp - epochScheduledDeparture;
+          }
         }
 
         /** Calculate the BoatETA as a function of the progress we have made on the journey. We use this value unless we do not get
@@ -142,6 +146,7 @@ export default {
         targetRoute['portData'][departingPort].BoatAtDock = AtDock && InService;
         targetRoute['portData'][arrivingPort].PortArrivalTimeMinus = arrivalTimeEta;
         targetRoute['portData'][arrivingPort].PortETA = epochEta;
+        targetRoute['portData'][departingPort].PortDepartureDelay = boatDelay;
       }
     }
 


### PR DESCRIPTION
Fixed the way boat delay is calculated so that it looks at the difference between scheduled departure and current time (from the WSDOT timestamp) when at the dock or reports the difference between actual departure and the scheduled departure. Also added this to port data.