### PR TITLE
14 compute departure delay average

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ferry-tempo-server",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@adobe/jsonschema2md": "^7.0.0",
@@ -15,6 +15,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.3",
         "node-fetch": "^3.2.0",
+        "node-persist": "^4.0.1",
         "nodemon": "^3.1.0",
         "pug": "^3.0.2",
         "winston": "^3.13.0"
@@ -6215,6 +6216,14 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
+    "node_modules/node-persist": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-4.0.1.tgz",
+      "integrity": "sha512-QtRjwAlcOQChQpfG6odtEhxYmA3nS5XYr+bx9JRjwahl1TM3sm9J3CCn51/MI0eoHRb2DrkEsCOFo8sq8jG5sQ==",
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -6751,11 +6760,11 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "node_modules/pug": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
-      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
+      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
       "dependencies": {
-        "pug-code-gen": "^3.0.2",
+        "pug-code-gen": "^3.0.3",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -6776,24 +6785,24 @@
       }
     },
     "node_modules/pug-code-gen": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
-      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
       "dependencies": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.0.0",
-        "pug-runtime": "^3.0.0",
+        "pug-error": "^2.1.0",
+        "pug-runtime": "^3.0.1",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "node_modules/pug-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
-      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg=="
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
@@ -12791,6 +12800,11 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
+    "node-persist": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-4.0.1.tgz",
+      "integrity": "sha512-QtRjwAlcOQChQpfG6odtEhxYmA3nS5XYr+bx9JRjwahl1TM3sm9J3CCn51/MI0eoHRb2DrkEsCOFo8sq8jG5sQ=="
+    },
     "node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -13181,11 +13195,11 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "pug": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
-      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
+      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
       "requires": {
-        "pug-code-gen": "^3.0.2",
+        "pug-code-gen": "^3.0.3",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -13206,24 +13220,24 @@
       }
     },
     "pug-code-gen": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
-      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
       "requires": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.0.0",
-        "pug-runtime": "^3.0.0",
+        "pug-error": "^2.1.0",
+        "pug-runtime": "^3.0.1",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "pug-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
-      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg=="
     },
     "pug-filters": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.4.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ferry-tempo-server",
-      "version": "1.4.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@adobe/jsonschema2md": "^7.0.0",
@@ -15,7 +15,6 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.3",
         "node-fetch": "^3.2.0",
-        "node-persist": "^4.0.1",
         "nodemon": "^3.1.0",
         "pug": "^3.0.2",
         "winston": "^3.13.0"
@@ -6216,14 +6215,6 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
-    "node_modules/node-persist": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-4.0.1.tgz",
-      "integrity": "sha512-QtRjwAlcOQChQpfG6odtEhxYmA3nS5XYr+bx9JRjwahl1TM3sm9J3CCn51/MI0eoHRb2DrkEsCOFo8sq8jG5sQ==",
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -6760,11 +6751,11 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "node_modules/pug": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
-      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
+      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
       "dependencies": {
-        "pug-code-gen": "^3.0.3",
+        "pug-code-gen": "^3.0.2",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -6785,24 +6776,24 @@
       }
     },
     "node_modules/pug-code-gen": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
-      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
+      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
       "dependencies": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.1.0",
-        "pug-runtime": "^3.0.1",
+        "pug-error": "^2.0.0",
+        "pug-runtime": "^3.0.0",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "node_modules/pug-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
-      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
@@ -12800,11 +12791,6 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
-    "node-persist": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-4.0.1.tgz",
-      "integrity": "sha512-QtRjwAlcOQChQpfG6odtEhxYmA3nS5XYr+bx9JRjwahl1TM3sm9J3CCn51/MI0eoHRb2DrkEsCOFo8sq8jG5sQ=="
-    },
     "node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -13195,11 +13181,11 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "pug": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
-      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
+      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
       "requires": {
-        "pug-code-gen": "^3.0.3",
+        "pug-code-gen": "^3.0.2",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -13220,24 +13206,24 @@
       }
     },
     "pug-code-gen": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
-      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
+      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
       "requires": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.1.0",
-        "pug-runtime": "^3.0.1",
+        "pug-error": "^2.0.0",
+        "pug-runtime": "^3.0.0",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "pug-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
-      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
     },
     "pug-filters": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.6.0",
+  "version": "1.5.0",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.3",
     "node-fetch": "^3.2.0",
-    "node-persist": "^4.0.1",
     "nodemon": "^3.1.0",
     "pug": "^3.0.2",
     "winston": "^3.13.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {
@@ -23,6 +23,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.3",
     "node-fetch": "^3.2.0",
+    "node-persist": "^4.0.1",
     "nodemon": "^3.1.0",
     "pug": "^3.0.2",
     "winston": "^3.13.0"

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -124,8 +124,10 @@ export default {
 
         // update the boatArrivalCache with the timestamp of the last position update for the vessel. Unset when not at dock.
         let timeAtDock = 0;
+        // use a combination of route and terminal since Seattle service multiple routes
+        let portKey = routeAbbreviation + DepartingTerminalAbbrev;
         let boatDelayAvg = getAverage(VesselName);
-        // let portDelayAvg = 0;
+        let portDelayAvg = getAverage(portKey);
         if (AtDock) {
           if (boatArrivalCache[VesselName]) {
             timeAtDock = getCurrentEpochSeconds() - boatArrivalCache[VesselName]
@@ -136,10 +138,8 @@ export default {
           // if not at the dock, see if there is a value in the cache, which indicates the boat just left.
           if (boatArrivalCache[VesselName]) {
             // boat just left the dock, update the average departure delay for the boat and the port
-            logger.debug('Updating boat delay average for:' + VesselName + ', arrival cache contents: ' + boatArrivalCache[VesselName]);
             boatDelayAvg = updateAverage(VesselName, boatDelay);
-            //let portKey = routeId + DepartingTerminalAbbrev;
-            //portDelayAvg = updateAvg(portKey, boatDelay);
+            portDelayAvg = updateAverage(portKey, boatDelay);
           }
           boatArrivalCache[VesselName] = null;
         }
@@ -194,6 +194,8 @@ export default {
             targetRoute['portData'][arrivingPort].PortETA = epochEta;
           }
         }
+        // it is oaky to update the average since this is kept unchanged until a boat leaves the port.
+        targetRoute['portData'][departingPort].PortDepartureDelayAverage = portDelayAvg;
       }
     }
 

--- a/src/StorageManager.js
+++ b/src/StorageManager.js
@@ -1,0 +1,48 @@
+/**
+ * StorageManage.js
+ * ============
+ * Handles the persistence of data for the service relying on node-persist library.
+ */
+import storage from 'node-persist';
+
+class StorageManager {
+    /**
+     * Initialize the storeage.
+     */
+    constructor() {
+      storage.init();
+    }
+
+    /**
+     * Store data into the local file system for persistence.
+     * @param key key for the data being stored.
+     * @param data value of the data being stored.
+     */
+    async setItem(key, value) {
+        await storage.setItem(key, value);
+    } 
+
+    /**
+     * Retrieve the data from the file system. Returns null if the data does not exist in the store or if the store doesn't exist.
+     * @param key key used to retrieve data from storage.
+     */
+    async getItem(key) {
+        return await storage.getItem(key);
+    }
+
+    /**
+     * Remove an item from the data stored under a particular key from the storage
+     * @param key key used to clear out the specified data
+     */
+    async removeItem(key) {
+        await storage.removeItem(key);
+    }
+
+    /**
+     * Clear local storage, used primarily for unit testing to clean up when done.
+     */
+    async clear() {
+        await storage.clear();
+    }
+}
+export default StorageManager;

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -180,18 +180,16 @@ export function updateAverage(key, value) {
   let delay = storage.getDelay(key);
 
   if (delay) {
-    logger.debug('Key (' + key + ') found in cache');
     count = delay['count'];
     average = Math.trunc((delay['average'] * count + average) / ++count);
   } else {
-    logger.debug('Key (' + key + ') not found in cache');
     delay = {};
   }
 
   delay['average'] = average;
   delay['count'] = count;
   storage.setDelay(key, delay);
-  logger.debug('Updated average:' + average + 'and count:' + count + ' for key:' + key);
+  logger.debug("Updated average departure delay for: " + key + " to: " + JSON.stringify(delay));
   return average;
 }   
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -167,22 +167,6 @@ export function calculateDistance(coord1, coord2) {
 }
 
 /**
- * Internal function to pull data from the persistent storage or iniatilize it if it doesn't exist.
- * TODO: Update this function to reset the data in the storage manager at 3am each day.
- * @return the delayCache stored in persistent manager.
- */
-function getDelayCache() {
-  // attempt to pull cache from persistent storage
-  const delayCache = storage.getItem('delayCache');
-  if (!delayCache) {
-    logger.debug('Local storage of delay cache is empty. Initializing with empty map');
-    delayCache = {};
-    storage.setItem('delayCache', delayCache);
-  } 
-  return delayCache;
-}
-
-/**
  * Updates the average calculation for the input key which can be a boat or a port on a route. 
  * Leverages the StorageManager to persist the average data from one restart to the next.
  * @param key Boat or port that is being updated.
@@ -192,27 +176,21 @@ function getDelayCache() {
 export function updateAverage(key, value) {
   let average = value;
   let count = 1;
- 
-  const delayCache = getDelayCache();
-  logger.debug('got delay cache: ' + JSON.stringify(delayCache));
-  let delay = delayCache[key];
+
+  let delay = storage.getDelay(key);
 
   if (delay) {
     logger.debug('Key (' + key + ') found in cache');
     count = delay['count'];
-    average = (delay['average'] * count + average) / ++count;
-    delay['average'] = average;
-    delay['count'] = count;
-    delayCache[key] = delay;
+    average = Math.trunc((delay['average'] * count + average) / ++count);
   } else {
     logger.debug('Key (' + key + ') not found in cache');
     delay = {};
-    delay['average'] = average;
-    delay['count'] = count;
-    delayCache.push(key, delay);
   }
 
-  storage.setItem('delayCache', delayCache);
+  delay['average'] = average;
+  delay['count'] = count;
+  storage.setDelay(key, delay);
   logger.debug('Updated average:' + average + 'and count:' + count + ' for key:' + key);
   return average;
 }   
@@ -221,8 +199,10 @@ export function updateAverage(key, value) {
  * Get the average value from storage for the input key
  */
 export function getAverage(key) {
-  const delayCache = getDelayCache();
-  if (delayCache[key]) {
-    return delayCache[key]['average'];
+  const delay = storage.getDelay(key);
+  if (delay) {
+    return delay['average'];
+  } else {
+    return 0;
   }
 }

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -1,0 +1,39 @@
+
+import StorageManager from '../src/StorageManager';
+
+describe('StorageManager', () => {
+    let storageManager;
+
+    beforeEach(() => {
+        storageManager = new StorageManager();
+    });
+
+    test('getDelay returns delay data when present', () => {
+        const key = 'boat1';
+        const delayData = { count: 5, averageDelay: 10 };
+        storageManager.setDelay(key, delayData);
+        expect(storageManager.getDelay(key)).toEqual(delayData);
+    });
+
+    test('getDelay returns null when delay data is not present', () => {
+        expect(storageManager.getDelay('nonExistentKey')).toBeNull();
+    });
+
+    test('setDelay sets delay data correctly', () => {
+        const key = 'boat1';
+        const delayData = { count: 5, averageDelay: 10 };
+        storageManager.setDelay(key, delayData);
+        expect(storageManager.getDelay(key)).toEqual(delayData);
+    });
+
+    test('setDelay updates existing delay data', () => {
+        const key = 'boat1';
+        const delayData = { count: 5, averageDelay: 10 };
+        storageManager.setDelay(key, delayData);
+
+        const newDelayData = { count: 7, averageDelay: 12 };
+        storageManager.setDelay(key, newDelayData);
+
+        expect(storageManager.getDelay(key)).toEqual(newDelayData);
+    });
+});

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -5,6 +5,8 @@ import {
   getProgress,
   calculateDistance,
   getHumanDateFromEpochSeconds,
+  updateAverage,
+  getAverage
 } from '../src/Utils.js';
 
 describe('getSecondsFromNow function', () => {
@@ -75,5 +77,34 @@ describe('getHumanDateFromEpochSeconds function', () => {
   // this test not only checks a certain date/time but also verifies pad() works
   test('should return the date May 7, 2024 at 10:51:00', () => {
     expect(getHumanDateFromEpochSeconds(1715104260)).toBe('2024-05-07 10:51:00');
+  });
+});
+
+describe('updateAverage function', () => {
+  test('should return the same value', () => {
+    const avg = 50;
+    // average of a single value should be that was input
+    expect(updateAverage('key1', avg)).toEqual(avg);
+  });
+  // testing that thea averages are properly calcualted across multiple entries
+  test('should return the average of several values', () => {
+    updateAverage('key2', 40);
+    updateAverage('key2', 100);
+    expect(updateAverage('key2', 100)).toEqual(80);
+  });
+  // testing that thea averages are properly calcualted across multiple entries with truncation
+  test('should return the average of several values', () => {
+    updateAverage('key3', 11);
+    // should truncate to 55
+    expect(updateAverage('key3', 100)).toEqual(55);
+  });
+});
+
+describe('getAverage function', () => {
+  test('should return 0 when we do not have an average', () => {
+    expect(getAverage('undefinedKey')).toEqual(0);
+  });
+  test('should return the value of precomputed average', () => {
+    expect(getAverage('key2')).toEqual(80);
   });
 });


### PR DESCRIPTION
This is a bit of an involved commit. In order to compute averages, we need to have stateful storage of the prior departure times. In order to keep storage down, I am just storing a running average and a count on a per boat and/or port basis. In this implementation the storage does not persist across restarts. In order to facilitate this in the future, I created a StorageManager class to allow us to modify the storage in the future. 

Also added unit tests for the StorageManager and for the new average functions inside Utils.