### PR TITLE
67 fix on duty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.5.0",
+  "version": "1.4.1",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -55,6 +55,8 @@ export default {
       } = vessel;
 
       const routeAbbreviation = OpRouteAbbrev[0];
+      // Calculating if a boat is on duty by looking at ArrivingTerminalAbbrev. However, sometimes when in dock it takes awhile to show up
+      const onDuty = AtDock ? InService : (InService && ArrivingTerminalAbbrev);
 
       // Check if this is a vessel we want to process, which has to be in service and has to be assigned to a route we care about.
       if (InService && routeAbbreviation && routeFTData[routeAbbreviation] && routePositionData[routeAbbreviation]) {
@@ -148,7 +150,7 @@ export default {
           'Heading': Heading,
           'InService': InService,
           'LeftDock': epochLeftDock,
-          'OnDuty': !!(InService && ArrivingTerminalAbbrev),
+          'OnDuty': onDuty,
           'PositionUpdated': epochTimeStamp,
           'Progress': AtDock ? 0 : getProgress(routeData, currentLocation),
           'ScheduledDeparture': epochScheduledDeparture,
@@ -157,6 +159,10 @@ export default {
           'VesselName': VesselName,
           'VesselPosition': VesselPositionNum,
         };
+
+        if( !onDuty ) {
+          logger.debug(VesselName + "is out of service");
+        }
 
         /**
          * Sometimes two boats on the same route will have the same departingPort and arrivingPort. In this case, we need to be careful setting

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -160,8 +160,10 @@ export default {
           'VesselPosition': VesselPositionNum,
         };
 
+        // if a boat is not on duty, we do not want to update the port data from that boat's data
         if( !onDuty ) {
-          logger.debug(VesselName + 'is out of service');
+          logger.debug(VesselName + 'is out of service, skipping port updates.');
+          return;
         }
 
         /**

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -161,7 +161,7 @@ export default {
         };
 
         if( !onDuty ) {
-          logger.debug(VesselName + "is out of service");
+          logger.debug(VesselName + 'is out of service');
         }
 
         /**


### PR DESCRIPTION
This is a fairly small change to calculate whether or not a boat is on duty by looking at a combination of InService, AtDock, and ArrivingTerminal. Unfortunately, the value for ArrivingTerminal is set to null for a portion of the time a boat is AtDock. So, we cannot rely on that value until a boat is at sea. The other part of the change, is to keep from updating port data with data from boats that are out of service.