### PR TITLE
fixed bug in logic that stops cache from being reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -14,9 +14,18 @@ import { createLogger, format, transports } from 'winston';
 
 class Logger {
   constructor() {
+    // Adding timestamp to the front of log lines on the console.
+    const tsFormat = format.printf(info => {
+      return `${info.timestamp} ${info.level}: ${info.message}`
+    })
+
     this.logger = createLogger({
       level: process.env.LOG_LEVEL || 'info',
-      format: format.cli(),
+      format: format.combine(
+        format.timestamp(),
+        format.colorize(),
+        tsFormat
+      ),
       transports: [
         new transports.Console(),
       ]

--- a/src/StorageManager.js
+++ b/src/StorageManager.js
@@ -4,6 +4,9 @@
  * Handles the persistence of data for the service relying on an in memory structure for now, but
  * abstracted so we can move to a database in the future.
  */
+import Logger from './Logger.js';
+const logger = new Logger();
+
 class StorageManager {
     /**
      * Initialize the storeage.
@@ -21,13 +24,15 @@ class StorageManager {
      */
     checkCacheReset() {
         let now = new Date();
-        if (now.getHours() == 3 && (lastCacheReset - now) > 3600000) {
+        if (now.getHours() == 3 && (now - this.lastCacheReset) > 3600000) {
             for (var prop in delayStorage) { 
                 if (delayStorage.hasOwnProperty(prop)) { 
                     delete delayStorage[prop]; 
                 } 
             }
+            delayStorage = {};
             this.lastCacheReset = now.getTime();
+            logger.debug("RESETTING departure delay cache.");
         }
     }
 


### PR DESCRIPTION
Unfortunately, I didn't catch a bug in the logic used to reset the delay cache. So it failed to reset last night, carrying over the averages from the day before. I am not sure how to unit test this given the need to modify the Date function as well as override the hour delay to stop resets. But I did test the logic through debug messaging this time.