### PR TITLE
Fixed logging and error with dual definitino for pad

### DIFF
--- a/src/RouteUtilities.js
+++ b/src/RouteUtilities.js
@@ -81,7 +81,7 @@ export function handleShipProgress(rawInfo) {
 
     // if we are locked for update, ignore this update to avoid concurent access
     if (lockedForUpdate) {
-        logger.info(`Locked for update: Ignoring update for ${shipName}`);
+        logger.info(`AIS: Locked for update: Ignoring update for ${shipName}`);
         return;
     }
 
@@ -113,7 +113,7 @@ export function handleShipProgress(rawInfo) {
         }
 
         if (positionFound === false) {
-            logger.error(`No route assignment for ${boat['VesselName']}`);
+            logger.info(`AIS: No route assignment for ${boat['VesselName']}`);
             logger.debug(`Assignments: ${JSON.stringify(routeAssignments)}`);
             return;
         }
@@ -121,7 +121,7 @@ export function handleShipProgress(rawInfo) {
         // see if the ship is still on the same route we have already assigned it to
         let [segmentIdx, fraction, distance] = closestToRoute(boat['AssignedRoute'], shipLatitude, shipLongitude);
         if (distance > MAX_DISTANCE_FROM_ROUTE) {
-            logger.info(`${boat['VesselName']}: Too far from route ${routeIdx}, distance is ${Number(distance).toFixed(2)} nm`);
+            logger.info(`AIS: ${boat['VesselName']}: Too far from route ${routeIdx}, distance is ${Number(distance).toFixed(2)} nm`);
             // The ship is too far from the route. Dissociate it.
             routeAssignments[boat['AssignedRoute']][boat['AssignedPosition']-1].isAssigned = false;
             boat['AssignedRoute'] = '';
@@ -153,7 +153,7 @@ export function handleShipProgress(rawInfo) {
     } else {
         direction = heading > 0 && heading < 180 ? 'ES' : 'WN';
         if (boat['Direction'] !== '' && boat['Direction'] !== direction) {
-            logger.info(`${boat['VesselName']}: Direction changed from ${boat['Direction']} to ${direction} while enroute`);
+            logger.info(`AIS: ${boat['VesselName']}: Direction changed from ${boat['Direction']} to ${direction} while enroute`);
         }
     }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -64,13 +64,6 @@ export function getCurrentEpochSeconds() {
  */
 function pad(n) {return n<10 ? '0'+n : n}
 
-/**
- * Internal function to pad a single integer with a leading zero if it is less than 10
- * @param {} n 
- * @returns 
- */
-function pad(n) {return n<10 ? '0'+n : n}
-
 /** 
  * Return the provided epoch time value into a string for use in logging and debugging
  * @return {string} The input epoch time converted to human readable format


### PR DESCRIPTION
Introduced an error with merge, where the pad function was declared twice and turned AIS logging into a little less verbose.