### PR TITLE
Added an api to pull sun-times data (sunrise/sunset)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferry-tempo-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A full-stack implementation of the FerryTempo FTServer. Provides API endpoints and live debugging views.",
   "main": "App.js",
   "scripts": {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -81,6 +81,17 @@ export function getHumanDateFromEpochSeconds(epochSec) {
   pad(d.getSeconds());
 }
 
+/**
+ * Return the time from the input epoch time value in the format HH:MM
+ * @param {number} epochSec - The epoch time in seconds
+ * @return {string} - The time in HH:MM format
+ */
+export function getTimeFromEpochSeconds(epochSec) {
+  let epochTime = epochSec * 1000;
+  let d = new Date(epochTime);
+  return pad(d.getHours()) + ':' + pad(d.getMinutes());
+}
+
 /** 
  * Determine if the input epoch time is a solstice
  * @param {number} epochSec - The epoch time in seconds


### PR DESCRIPTION
Added an API to return the sunrise and sunset times in order to support automated dimming on the client. This currently defaults to Bainbridge at all times but has the ability to leverage the city parameter (which is the home port on the client).