### PR TITLE
Changed to using a timezone sensitive implementation to return SunTimes

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -89,8 +89,17 @@ export function getHumanDateFromEpochSeconds(epochSec) {
 export function getTimeFromEpochSeconds(epochSec) {
   let epochTime = epochSec * 1000;
   let d = new Date(epochTime);
-  return pad(d.getHours()) + ':' + pad(d.getMinutes());
+  
+  // Get the time in the local timezone using toLocaleTimeString
+  let timeString = d.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false // Set to true if you want 12-hour format (e.g., AM/PM)
+  });
+  
+  return timeString;
 }
+
 
 /** 
  * Determine if the input epoch time is a solstice

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -11,7 +11,8 @@ import {
   getAverage,
   getRouteFromTerminals,
   getBoatAssignments,
-  getBoatsOnRoute
+  getBoatsOnRoute,
+  getTimeFromEpochSeconds
 } from '../src/Utils.js';
 
 describe('getSecondsFromNow function', () => {
@@ -326,5 +327,14 @@ describe('getBoatsOnRoute function', () => {
         }
       ];
     expect(getBoatsOnRoute(boatData)).toEqual(boatAssignments);
+  });
+});
+
+describe('getTimeFromEpoch function', () => {
+  test('should return 07:40', () => {
+    expect(getTimeFromEpochSeconds(1733240445)).toBe("07:40");
+  });
+  test('should return 04:19', () => {
+    expect(getTimeFromEpochSeconds(1733271596)).toBe("16:19");
   });
 });


### PR DESCRIPTION
Quick fix to ensure we are using timezone when computing hh:mm from epochseconds