### PR TITLE
Fixed crash when aistream.io is down and put boats off duty if at fue…

### DIFF
--- a/src/AISWorker.js
+++ b/src/AISWorker.js
@@ -57,7 +57,10 @@ function connectToAis(apiKey) {
     //  When it closes, wait 10 seconds then re-connect.
     //  Ignore errors, the 'close' signal is also issued.
     aisSocket.onopen = () => { subscribe(apiKey); };
-    aisSocket.onclose = () => { setTimeout(connectToAis(apiKey), 10 * 1000); };
+    aisSocket.onclose = () => {
+        logger.error("Connection to aisstream.io closed, attempting to reconnect in 10 seconds...");
+        setTimeout(() => connectToAis(apiKey), 10 * 1000);
+    };
     aisSocket.onerror = () => {
         logger.error("Error connecting to aisstream.io");
         aisSocket.close();

--- a/src/App.js
+++ b/src/App.js
@@ -301,7 +301,7 @@ app.get('/api/v1/check-update', (req, res) => {
 app.get('/api/v1/update', (req, res) => {
   const clientVersion = validator.escape(req.query.version);
   const model = validator.escape(req.query.hw);
-  const type = validator.escape(req.query.type);
+  const updateType = validator.escape(req.query.type);
 
   if (!clientVersion || !model) {
     return res.status(400).send('Version and model parameters are required.');

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -110,11 +110,12 @@ export default {
 
       // Calculating if a boat is on duty by looking at the system shut flag and message. If the flag is not 0 and the message is out of service, 
       // then the boat is not onDuty
-      const onDuty = InService  ? !(VesselWatchShutFlag != 0 && VesselWatchShutMsg.toLowerCase().includes('vessel out of service')) : false;
+      var onDuty = InService  ? !(VesselWatchShutFlag != 0 && VesselWatchShutMsg.toLowerCase().includes('vessel out of service')) : false;
 
-      // Debug message for when a boat is going to/from the Fuel Dock, which should be considered out of service. (set to info to catch on server)
+      // Debug message for when a boat is going to/from the Fuel Dock, which should be considered off duty.
       if (onDuty && (ArrivingTerminalAbbrev === 'P15' || DepartingTerminalAbbrev === 'P15')) {
-        logger.info(VesselName +  'is showing Fuel Dock while still on duty');
+        logger.debug (VesselName +  ' is showing Fuel Dock while still on duty. Changing to off duty.');
+        onDuty = false;
       }
 
       // Check if this is a vessel we want to process, which has to be in service and has to be assigned to a route we care about.


### PR DESCRIPTION
Fixed two declaration errors. One caused the server to crash if/when aisstream closes the connection to our web app. The other caused a crash when trying to access an update file. Also included a fix that puts boats at the fuel dock into off duty so as to not confuse devices.