### PR TITLE
143 upgrade to tar fs 214

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8319,9 +8319,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "engines": {
         "node": ">= 0.10"
       }


### PR DESCRIPTION
Updated the dependency of tar-fs to 2.14 to address critical vulnerability. Also addressed a moderate vulnerability in validator.js.