### PR TITLE
Expire stale scheduled departure overrides

### DIFF
--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -90,8 +90,13 @@ function applyScheduleData(ferryTempoData, scheduleData, referenceTime, activeSc
           .sort((first, second) => first - second);
 
       portData.PortScheduleList = scheduleList;
-      portData.NextScheduledDeparture = activeScheduledDepartureCandidates[getPortDelayCacheKey(routeAbbreviation, portKey)] ??
-          scheduleList.find((departingTime) => departingTime >= referenceTime) ?? null;
+      const scheduleCandidate = scheduleList.find((departingTime) => departingTime >= referenceTime) ?? null;
+      const activeCandidate = activeScheduledDepartureCandidates[getPortDelayCacheKey(routeAbbreviation, portKey)];
+      const nextAfterActiveCandidate = scheduleList.find((departingTime) => departingTime > activeCandidate);
+      const activeCandidateIsCurrent = activeCandidate &&
+          (!nextAfterActiveCandidate || referenceTime < nextAfterActiveCandidate);
+
+      portData.NextScheduledDeparture = activeCandidateIsCurrent ? activeCandidate : scheduleCandidate;
     }
   }
 }

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -243,4 +243,36 @@ describe('FerryTempo.processFerryData', () => {
 
     expect(departedCycle['ed-king']['portData']['portES']['NextScheduledDeparture']).toBe(1710301800);
   });
+
+  test('expires an overdue at-dock departure when the next scheduled slot passes', () => {
+    const scheduleData = {
+      'ed-king': {
+        TerminalCombos: [
+          {
+            DepartingTerminalID: 8,
+            ArrivingTerminalID: 12,
+            Times: [
+              { DepartingTime: wsdotDate(1710400000) },
+              { DepartingTime: wsdotDate(1710401800) },
+              { DepartingTime: wsdotDate(1710403600) },
+            ],
+          },
+        ],
+      },
+    };
+
+    const ferryTempoData = FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 8,
+        VesselName: 'Stale Schedule Boat',
+        Mmsi: 888888888,
+        AtDock: true,
+        LeftDock: null,
+        TimeStamp: wsdotDate(1710401900),
+        ScheduledDeparture: wsdotDate(1710400000),
+      }),
+    ], scheduleData);
+
+    expect(ferryTempoData['ed-king']['portData']['portES']['NextScheduledDeparture']).toBe(1710403600);
+  });
 });


### PR DESCRIPTION
Keep an overdue at-dock ScheduledDeparture active only until the next official scheduled slot for that port has passed.

This preserves legitimate late departures without letting stale WSF vessel metadata hold NextScheduledDeparture for multiple schedule slots.

Add regression coverage for an at-dock boat reporting an old scheduled departure after the following scheduled slot has already passed.