### PR TITLE
Add terminal alerts and vehicle spaces

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,12 @@
 import 'dotenv/config';
 import express from 'express';
 import Database from 'better-sqlite3';
-import { fetchScheduleData, fetchVesselData } from './WSDOT.js';
+import {
+  fetchScheduleData,
+  fetchTerminalBulletinData,
+  fetchTerminalSailingSpaceData,
+  fetchVesselData,
+} from './WSDOT.js';
 import FerryTempo, { debugProgress } from './FerryTempo.js';
 import Logger from './Logger.js';
 import fs from 'fs';
@@ -26,22 +31,33 @@ const PORT = process.env.PORT || 8080;
 const app = express();
 const fetchInterval = 5000;
 const scheduleFetchInterval = 600000;
+const terminalBulletinFetchInterval = 600000;
+const terminalSailingSpaceFetchInterval = 5000;
 const appVersion = process.env.npm_package_version;
 const logger = new Logger();
 let latestAisData = null;
 let latestScheduleData = null;
 let latestScheduleTripDate = null;
 let scheduleFetchInFlight = false;
+let latestTerminalBulletinData = null;
+let terminalBulletinFetchInFlight = false;
+let latestTerminalSailingSpaceData = null;
+let terminalSailingSpaceFetchInFlight = false;
 
-function filterDeviceRouteData(routeData) {
+function filterDeviceRouteData(routeData, includeScheduleList = false) {
   const filteredRouteData = JSON.parse(JSON.stringify(routeData));
   for (const boatKey in filteredRouteData.boatData) {
     delete filteredRouteData.boatData[boatKey].CrossingTimeAverage;
     delete filteredRouteData.boatData[boatKey].StopTimerAverage;
   }
   for (const portKey in filteredRouteData.portData) {
-    delete filteredRouteData.portData[portKey].PortScheduleList;
+    if (!includeScheduleList) {
+      delete filteredRouteData.portData[portKey].PortScheduleList;
+    }
     delete filteredRouteData.portData[portKey].PortStopTimerAverage;
+    delete filteredRouteData.portData[portKey].TerminalAlerts;
+    delete filteredRouteData.portData[portKey].VehicleSpacesRemaining;
+    delete filteredRouteData.portData[portKey].VehicleSpaces;
   }
   return filteredRouteData;
 }
@@ -180,8 +196,8 @@ app.get('/api/v1/route/:routeId', (request, response) => {
 
   if (ferryTempoData && typeof ferryTempoData === 'object' && ferryTempoData.hasOwnProperty(routeId)) {
     const includeScheduleList = request.query.includeScheduleList === 'true' || request.query.includeSchedules === 'true';
-    const routeData = request.query.cid && !includeScheduleList ?
-      filterDeviceRouteData(ferryTempoData[routeId]) :
+    const routeData = request.query.cid ?
+      filterDeviceRouteData(ferryTempoData[routeId], includeScheduleList) :
       ferryTempoData[routeId];
 
     response.setHeader('Content-Type', 'application/json');
@@ -456,6 +472,38 @@ const fetchScheduleDataForCurrentSailingDay = () => {
       });
 };
 
+const fetchTerminalBulletinDataForPorts = () => {
+  if (terminalBulletinFetchInFlight) {
+    return;
+  }
+
+  terminalBulletinFetchInFlight = true;
+  fetchTerminalBulletinData()
+      .then((terminalBulletinData) => {
+        latestTerminalBulletinData = terminalBulletinData;
+      })
+      .catch((error) => logger.error(`WSDOT terminal bulletins are returning: ${error}`))
+      .finally(() => {
+        terminalBulletinFetchInFlight = false;
+      });
+};
+
+const fetchTerminalSailingSpaceDataForPorts = () => {
+  if (terminalSailingSpaceFetchInFlight) {
+    return;
+  }
+
+  terminalSailingSpaceFetchInFlight = true;
+  fetchTerminalSailingSpaceData()
+      .then((terminalSailingSpaceData) => {
+        latestTerminalSailingSpaceData = terminalSailingSpaceData;
+      })
+      .catch((error) => logger.error(`WSDOT terminal sailing spaces are returning: ${error}`))
+      .finally(() => {
+        terminalSailingSpaceFetchInFlight = false;
+      });
+};
+
 // Start the data processing loop.
 const fetchAndProcessData = () => {
   const currentScheduleTripDate = getSailingDayId();
@@ -465,7 +513,12 @@ const fetchAndProcessData = () => {
 
   fetchVesselData()
       .then((vesselData) => {
-        const ferryTempoData = FerryTempo.processFerryData(vesselData, latestScheduleData);
+        const ferryTempoData = FerryTempo.processFerryData(
+            vesselData,
+            latestScheduleData,
+            latestTerminalBulletinData,
+            latestTerminalSailingSpaceData,
+        );
 
         // Create a row for the latest data.
         const insert = db.prepare(`
@@ -493,6 +546,14 @@ const fetchAndProcessData = () => {
 logger.info(`Fetching schedule data every ${scheduleFetchInterval / 1000} seconds.`);
 fetchScheduleDataForCurrentSailingDay();
 setInterval(fetchScheduleDataForCurrentSailingDay, scheduleFetchInterval);
+
+logger.info(`Fetching terminal bulletin data every ${terminalBulletinFetchInterval / 1000} seconds.`);
+fetchTerminalBulletinDataForPorts();
+setInterval(fetchTerminalBulletinDataForPorts, terminalBulletinFetchInterval);
+
+logger.info(`Fetching terminal sailing space data every ${terminalSailingSpaceFetchInterval / 1000} seconds.`);
+fetchTerminalSailingSpaceDataForPorts();
+setInterval(fetchTerminalSailingSpaceDataForPorts, terminalSailingSpaceFetchInterval);
 
 logger.info(`Fetching vessel data every ${fetchInterval / 1000} seconds.`);
 fetchAndProcessData();

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -101,13 +101,140 @@ function applyScheduleData(ferryTempoData, scheduleData, referenceTime, activeSc
   }
 }
 
+function decodeBasicHtmlEntities(value) {
+  if (!value) {
+    return '';
+  }
+
+  return value
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'");
+}
+
+function getPlainTextFromHtml(value) {
+  return decodeBasicHtmlEntities(value.replace(/<[^>]*>/g, ' '))
+      .replace(/\s+/g, ' ')
+      .trim();
+}
+
+function applyTerminalBulletinData(ferryTempoData, terminalBulletinData) {
+  if (!Array.isArray(terminalBulletinData)) {
+    return;
+  }
+
+  const bulletinsByTerminalId = Object.fromEntries(
+      terminalBulletinData.map((terminalBulletin) => [terminalBulletin.TerminalID, terminalBulletin]),
+  );
+
+  for (const routeAbbreviation in ferryTempoData) {
+    for (const portKey of ['portWN', 'portES']) {
+      const portData = ferryTempoData[routeAbbreviation].portData[portKey];
+      const terminalBulletin = bulletinsByTerminalId[portData.TerminalID];
+      portData.TerminalAlerts = (terminalBulletin?.Bulletins || [])
+          .map((bulletin) => ({
+            Title: bulletin.BulletinTitle || '',
+            Text: getPlainTextFromHtml(bulletin.BulletinText || ''),
+            Html: bulletin.BulletinText || '',
+            SortSeq: bulletin.BulletinSortSeq ?? null,
+            LastUpdated: getEpochSecondsFromWSDOT(bulletin.BulletinLastUpdated),
+          }))
+          .sort((first, second) => (first.SortSeq ?? 0) - (second.SortSeq ?? 0));
+    }
+  }
+}
+
+function getMatchingArrivalSpace(departureSpace, arrivingTerminalId) {
+  return (departureSpace.SpaceForArrivalTerminals || []).find((arrivalSpace) => {
+    return arrivalSpace.TerminalID === arrivingTerminalId ||
+        (arrivalSpace.ArrivalTerminalIDs || []).includes(arrivingTerminalId);
+  });
+}
+
+function getVehicleSpaceForPort(terminalSpaceData, arrivingTerminalId, targetDeparture, referenceTime) {
+  const departures = (terminalSpaceData?.DepartingSpaces || [])
+      .map((departureSpace) => ({
+        departureSpace,
+        arrivalSpace: getMatchingArrivalSpace(departureSpace, arrivingTerminalId),
+        departureTime: getEpochSecondsFromWSDOT(departureSpace.Departure),
+      }))
+      .filter((space) => space.arrivalSpace && space.departureTime > 0)
+      .sort((first, second) => first.departureTime - second.departureTime);
+
+  if (departures.length === 0) {
+    return null;
+  }
+
+  return departures.find((space) => targetDeparture && space.departureTime === targetDeparture) ||
+      departures.find((space) => space.departureTime >= referenceTime) ||
+      null;
+}
+
+function applyTerminalSailingSpaceData(ferryTempoData, terminalSailingSpaceData, referenceTime) {
+  if (!Array.isArray(terminalSailingSpaceData)) {
+    return;
+  }
+
+  const spacesByTerminalId = Object.fromEntries(
+      terminalSailingSpaceData.map((terminalSpaceData) => [terminalSpaceData.TerminalID, terminalSpaceData]),
+  );
+
+  for (const routeAbbreviation in ferryTempoData) {
+    const routeData = ferryTempoData[routeAbbreviation];
+    const oppositePortKey = {
+      portWN: 'portES',
+      portES: 'portWN',
+    };
+
+    for (const portKey of ['portWN', 'portES']) {
+      const portData = routeData.portData[portKey];
+      const arrivingPortData = routeData.portData[oppositePortKey[portKey]];
+      const terminalSpaceData = spacesByTerminalId[portData.TerminalID];
+      const vehicleSpace = getVehicleSpaceForPort(
+          terminalSpaceData,
+          arrivingPortData.TerminalID,
+          portData.NextScheduledDeparture,
+          referenceTime,
+      );
+
+      if (!vehicleSpace) {
+        portData.VehicleSpacesRemaining = null;
+        portData.VehicleSpaces = null;
+        continue;
+      }
+
+      portData.VehicleSpacesRemaining = vehicleSpace.arrivalSpace.DisplayDriveUpSpace ?
+        vehicleSpace.arrivalSpace.DriveUpSpaceCount :
+        null;
+      portData.VehicleSpaces = {
+        Departure: vehicleSpace.departureTime,
+        IsCancelled: vehicleSpace.departureSpace.IsCancelled,
+        VesselID: vehicleSpace.departureSpace.VesselID,
+        VesselName: vehicleSpace.departureSpace.VesselName,
+        ArrivingTerminalID: vehicleSpace.arrivalSpace.TerminalID,
+        ArrivingTerminalName: vehicleSpace.arrivalSpace.TerminalName,
+        DisplayDriveUpSpace: vehicleSpace.arrivalSpace.DisplayDriveUpSpace,
+        DriveUpSpaceCount: vehicleSpace.arrivalSpace.DriveUpSpaceCount,
+        DriveUpSpaceHexColor: vehicleSpace.arrivalSpace.DriveUpSpaceHexColor,
+        DisplayReservableSpace: vehicleSpace.arrivalSpace.DisplayReservableSpace,
+        ReservableSpaceCount: vehicleSpace.arrivalSpace.ReservableSpaceCount,
+        ReservableSpaceHexColor: vehicleSpace.arrivalSpace.ReservableSpaceHexColor,
+        MaxSpaceCount: vehicleSpace.arrivalSpace.MaxSpaceCount ?? vehicleSpace.departureSpace.MaxSpaceCount,
+      };
+    }
+  }
+}
+
 export default {
   /**
    * Crunches the ferry data into the proper Ferry Tempo format.
    * @param {object} vesselData - VesselData object containing updated WSDOT ferry data
    * @return {object} updated Ferry Tempo data object.
    */
-  processFerryData: (vesselData, scheduleData = null) => {
+  processFerryData: (vesselData, scheduleData = null, terminalBulletinData = null, terminalSailingSpaceData = null) => {
     // Create a fresh ferryTempoData object to fill
     const updatedFerryTempoData = JSON.parse(JSON.stringify(routeFTData));
 
@@ -437,6 +564,12 @@ export default {
         scheduleData,
         latestEventTime || getCurrentEpochSeconds(),
         activeScheduledDepartureCandidates,
+    );
+    applyTerminalBulletinData(updatedFerryTempoData, terminalBulletinData);
+    applyTerminalSailingSpaceData(
+        updatedFerryTempoData,
+        terminalSailingSpaceData,
+        latestEventTime || getCurrentEpochSeconds(),
     );
 
     return updatedFerryTempoData;

--- a/src/WSDOT.js
+++ b/src/WSDOT.js
@@ -9,15 +9,17 @@
 import fetch from 'node-fetch';
 import routeFTData from '../data/RouteFTData.js';
 
-export const fetchVesselData = async function() {
-  return fetch(`https://www.wsdot.wa.gov/ferries/api/vessels/rest/vessellocations?apiaccesscode=${process.env.WSDOT_API_KEY}`)
-      .then((response) => {
-        if (!response.ok) {
-          throw Error(response.statusText);
-        }
+async function fetchWSDOTJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw Error(response.statusText);
+  }
 
-        return response.json();
-      });
+  return response.json();
+}
+
+export const fetchVesselData = async function() {
+  return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/vessels/rest/vessellocations?apiaccesscode=${process.env.WSDOT_API_KEY}`);
 };
 
 export const fetchScheduleData = async function(tripDate) {
@@ -25,17 +27,18 @@ export const fetchScheduleData = async function(tripDate) {
     const routeId = routeData.routeID;
     const scheduleUrl = `https://www.wsdot.wa.gov/ferries/api/schedule/rest/schedule/${tripDate}/${routeId}?apiaccesscode=${process.env.WSDOT_API_KEY}`;
 
-    return fetch(scheduleUrl)
-        .then((response) => {
-          if (!response.ok) {
-            throw Error(response.statusText);
-          }
-
-          return response.json();
-        })
+    return fetchWSDOTJson(scheduleUrl)
         .then((scheduleData) => [routeAbbreviation, scheduleData]);
   });
 
   const routeSchedules = await Promise.all(routeScheduleRequests);
   return Object.fromEntries(routeSchedules);
+};
+
+export const fetchTerminalBulletinData = async function() {
+  return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/terminals/rest/terminalbulletins?apiaccesscode=${process.env.WSDOT_API_KEY}`);
+};
+
+export const fetchTerminalSailingSpaceData = async function() {
+  return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/terminals/rest/terminalsailingspace?apiaccesscode=${process.env.WSDOT_API_KEY}`);
 };

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -275,4 +275,90 @@ describe('FerryTempo.processFerryData', () => {
 
     expect(ferryTempoData['ed-king']['portData']['portES']['NextScheduledDeparture']).toBe(1710403600);
   });
+
+  test('adds terminal alerts and vehicle spaces to port data', () => {
+    const scheduleData = {
+      'ed-king': {
+        TerminalCombos: [
+          {
+            DepartingTerminalID: 8,
+            ArrivingTerminalID: 12,
+            Times: [
+              { DepartingTime: wsdotDate(1710500600) },
+            ],
+          },
+        ],
+      },
+    };
+    const terminalBulletinData = [
+      {
+        TerminalID: 8,
+        Bulletins: [
+          {
+            BulletinTitle: 'Dock alert',
+            BulletinText: '<p>Use lane &amp; booth 2.</p>',
+            BulletinSortSeq: 1,
+            BulletinLastUpdated: wsdotDate(1710500000),
+          },
+        ],
+      },
+    ];
+    const terminalSailingSpaceData = [
+      {
+        TerminalID: 8,
+        DepartingSpaces: [
+          {
+            Departure: wsdotDate(1710500600),
+            IsCancelled: false,
+            VesselID: 1,
+            VesselName: 'Test Boat',
+            MaxSpaceCount: 144,
+            SpaceForArrivalTerminals: [
+              {
+                TerminalID: 12,
+                TerminalName: 'Kingston',
+                DisplayDriveUpSpace: true,
+                DriveUpSpaceCount: 42,
+                DriveUpSpaceHexColor: '#00FF00',
+                DisplayReservableSpace: false,
+                ReservableSpaceCount: null,
+                ReservableSpaceHexColor: null,
+                MaxSpaceCount: 144,
+                ArrivalTerminalIDs: [12],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const ferryTempoData = FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 9,
+        VesselName: 'Terminal Data Boat',
+        Mmsi: 999999999,
+        TimeStamp: wsdotDate(1710500100),
+        ScheduledDeparture: wsdotDate(1710500600),
+      }),
+    ], scheduleData, terminalBulletinData, terminalSailingSpaceData);
+
+    expect(ferryTempoData['ed-king']['portData']['portES']['TerminalAlerts']).toEqual([
+      {
+        Title: 'Dock alert',
+        Text: 'Use lane & booth 2.',
+        Html: '<p>Use lane &amp; booth 2.</p>',
+        SortSeq: 1,
+        LastUpdated: 1710500000,
+      },
+    ]);
+    expect(ferryTempoData['ed-king']['portData']['portES']['VehicleSpacesRemaining']).toBe(42);
+    expect(ferryTempoData['ed-king']['portData']['portES']['VehicleSpaces']).toMatchObject({
+      Departure: 1710500600,
+      VesselID: 1,
+      VesselName: 'Test Boat',
+      ArrivingTerminalID: 12,
+      DriveUpSpaceCount: 42,
+      MaxSpaceCount: 144,
+    });
+  });
 });


### PR DESCRIPTION
Fetch WSF terminal bulletins and sailing-space data separately from the main vessel loop, polling alerts less frequently while keeping vehicle-space counts fresh. Map terminal alerts and next-departure vehicle-space details onto port data for app clients, and omit those app-only fields from hardware device responses. Add FerryTempo coverage for alert text normalization and vehicle-space mapping.