### PR TITLE
Align port ETA with computed countdown

### DIFF
--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -396,6 +396,9 @@ export default {
             }
           }
         }
+        const computedArrivalEta = arrivalTimeEta > 0 && epochTimeStamp > 0 ?
+          epochTimeStamp + arrivalTimeEta :
+          epochEta;
 
         // update the boatArrivalCache with the timestamp of the last position update for the vessel. Unset when not at dock.
         let timeAtDock = 0;
@@ -525,7 +528,7 @@ export default {
           targetRoute['portData'][departingPort].PortStopTimer = timeAtDock;
           targetRoute['portData'][departingPort].PortStopTimerAverage = portStopTimerAvg;
           targetRoute['portData'][arrivingPort].PortArrivalTimeMinus = arrivalTimeEta;
-          targetRoute['portData'][arrivingPort].PortETA = epochEta;
+          targetRoute['portData'][arrivingPort].PortETA = computedArrivalEta;
           routeDirCache[routeDirKey] = true;
         } else {
           if (AtDock) {
@@ -535,7 +538,7 @@ export default {
           }
           if ((arrivalTimeEta > 0) && (arrivalTimeEta < targetRoute['portData'][arrivingPort].PortArrivalTimeMinus)) {
             targetRoute['portData'][arrivingPort].PortArrivalTimeMinus = arrivalTimeEta;
-            targetRoute['portData'][arrivingPort].PortETA = epochEta;
+            targetRoute['portData'][arrivingPort].PortETA = computedArrivalEta;
           }
         }
         // it is oaky to update the average since this is kept unchanged until a boat leaves the port.

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -157,6 +157,30 @@ describe('FerryTempo.processFerryData', () => {
     expect(arrivalCycle['ed-king']['boatData']['boat1']['CrossingTimeAverage']).toBe(480);
   });
 
+  test('sets port ETA to the computed arrival clock time that matches ArrivalTimeMinus', () => {
+    const eastPoint = routePositionData['ed-king'][routePositionData['ed-king'].length - 1];
+
+    const ferryTempoData = FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 10,
+        VesselName: 'Computed ETA Boat',
+        Mmsi: 101010101,
+        Latitude: eastPoint[0],
+        Longitude: eastPoint[1],
+        AtDock: false,
+        LeftDock: wsdotDate(1710600000),
+        Eta: wsdotDate(1710602000),
+        TimeStamp: wsdotDate(1710600100),
+        ScheduledDeparture: wsdotDate(1710600000),
+      }),
+    ]);
+
+    expect(ferryTempoData['ed-king']['boatData']['boat1']['BoatETA']).toBe(1710602000);
+    expect(ferryTempoData['ed-king']['boatData']['boat1']['ArrivalTimeMinus']).toBe(2000);
+    expect(ferryTempoData['ed-king']['portData']['portWN']['PortETA']).toBe(1710602100);
+    expect(ferryTempoData['ed-king']['portData']['portWN']['PortArrivalTimeMinus']).toBe(2000);
+  });
+
   test('adds port schedule lists and next scheduled sailing from schedule data', () => {
     const scheduleData = {
       'ed-king': {


### PR DESCRIPTION
Set PortETA from the boat position timestamp plus the FerryTempo-computed PortArrivalTimeMinus so the app's port clock time and boat countdown use the same ETA source. Keep BoatETA as the raw WSF ETA for debugging and visibility. This also gives the future AIS fallback a cleaner API contract: callers can keep using PortETA and ArrivalTimeMinus while the server swaps the internal ETA inputs from WSF vessel data to AIS position plus crossing estimates.