### PR TITLE
Fix AIS state cleanup and runtime cache issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@adobe/jsonschema2md": "^8.0.11",
         "ajv": "^8.11.0",
-        "better-sqlite3": "^12.8.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.3",
         "node-fetch": "^3.2.0",
@@ -2079,26 +2078,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
@@ -2112,20 +2091,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2136,26 +2101,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -2269,30 +2214,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2515,12 +2436,6 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -2834,21 +2749,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -2875,15 +2775,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2929,15 +2820,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -3080,15 +2962,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -3505,15 +3378,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -3713,12 +3577,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3879,12 +3737,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -4029,12 +3881,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -4226,26 +4072,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4325,12 +4151,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -6487,18 +6307,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -6512,15 +6320,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -6530,12 +6329,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "11.7.5",
@@ -6738,12 +6531,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6758,30 +6545,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -7040,6 +6803,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7352,33 +7116,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7583,16 +7320,6 @@
       "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
       "license": "MIT"
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7688,30 +7415,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -8148,51 +7851,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -8478,34 +8136,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -8655,18 +8285,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/tv4": {
@@ -9200,6 +8818,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@adobe/jsonschema2md": "^8.0.11",
     "ajv": "^8.11.0",
-    "better-sqlite3": "^12.8.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.3",
     "node-fetch": "^3.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,6 @@
  */
 import 'dotenv/config';
 import express from 'express';
-import Database from 'better-sqlite3';
 import {
   fetchScheduleData,
   fetchTerminalBulletinData,
@@ -14,6 +13,7 @@ import {
   fetchVesselData,
 } from './WSDOT.js';
 import FerryTempo, { debugProgress } from './FerryTempo.js';
+import InMemoryStore from './InMemoryStore.js';
 import Logger from './Logger.js';
 import fs from 'fs';
 import path from 'path';
@@ -96,100 +96,7 @@ if ((key == undefined) || (key == 'undefined') || (key == null)) {
   process.exit(-1);
 }
 
-// Set up SQLite database.
-const db = new Database(':memory:');
-db.pragma('journal_mode = WAL');
-process.on('exit', () => db.close());
-db.exec(`
-  CREATE TABLE AppData (
-    id INTEGER PRIMARY KEY,
-    saveDate INTEGER,
-    vesselData JSON,
-    ferryTempoData JSON
-  )
-`);
-db.exec(`
-  CREATE TABLE WeatherData (
-    id INTEGER PRIMARY KEY,
-    saveDate INTEGER,
-    openWeather JSON,
-    weatherData JSON
-  )
-`);
-db.exec(`
-  CREATE TABLE UpdateChecks (
-    id INTEGER PRIMARY KEY,
-    saveDate INTEGER,
-    deviceKey TEXT,
-    deviceCid TEXT,
-    ipAddress TEXT,
-    flashVersion TEXT,
-    spiffsVersion TEXT,
-    clientEnv TEXT,
-    hardwareModel TEXT,
-    updateType TEXT,
-    updateAvailable INTEGER
-  )
-`);
-
-const insertUpdateCheck = db.prepare(`
-  INSERT INTO UpdateChecks (
-    saveDate,
-    deviceKey,
-    deviceCid,
-    ipAddress,
-    flashVersion,
-    spiffsVersion,
-    clientEnv,
-    hardwareModel,
-    updateType,
-    updateAvailable
-  ) VALUES (
-    @saveDate,
-    @deviceKey,
-    @deviceCid,
-    @ipAddress,
-    @flashVersion,
-    @spiffsVersion,
-    @clientEnv,
-    @hardwareModel,
-    @updateType,
-    @updateAvailable
-  )
-`);
-
-const selectUpdateChecksForSummary = db.prepare(`
-  SELECT
-    saveDate,
-    deviceKey,
-    deviceCid,
-    ipAddress,
-    flashVersion,
-    spiffsVersion,
-    clientEnv,
-    hardwareModel,
-    updateType,
-    updateAvailable
-  FROM UpdateChecks
-  ORDER BY saveDate DESC, id DESC
-`);
-
-const selectRecentUpdateChecks = db.prepare(`
-  SELECT
-    saveDate,
-    deviceKey,
-    deviceCid,
-    ipAddress,
-    flashVersion,
-    spiffsVersion,
-    clientEnv,
-    hardwareModel,
-    updateType,
-    updateAvailable
-  FROM UpdateChecks
-  ORDER BY id DESC
-  LIMIT 500
-`);
+const store = new InMemoryStore();
 
 function sanitizeQueryValue(value) {
   const normalizedValue = Array.isArray(value) ? value.join(',') : `${value ?? ''}`;
@@ -258,7 +165,7 @@ function recordUpdateCheck(req, updateAvailable) {
   const requestInfo = getTrackedUpdateRequest(req);
   const deviceKey = buildDeviceKey(requestInfo);
 
-  insertUpdateCheck.run({
+  store.insertUpdateCheck({
     saveDate: Math.floor(Date.now() / 1000),
     deviceKey,
     deviceCid: requestInfo.cid,
@@ -339,15 +246,7 @@ app.get('/', (request, response) => {
 
 // Debug route for debugging and user-friendly routing. But limit results to avoid overloading memory
 app.get('/debug', (request, response) => {
-  const select = db.prepare(`
-    SELECT 
-      saveDate,
-      vesselData,
-      ferryTempoData 
-    FROM AppData
-    ORDER BY id DESC
-    LIMIT 1000`);
-  const events = select.all();
+  const events = store.getRecentAppData(1000);
 
   const sanitizedVersion = validator.escape(appVersion);
   response.render('debug', { events, version: sanitizedVersion });
@@ -355,14 +254,7 @@ app.get('/debug', (request, response) => {
 
 // Debug route for debugging and user-friendly routing.
 app.get('/debug/weather', (request, response) => {
-  const select = db.prepare(`
-    SELECT 
-      saveDate,
-      openWeather,
-      weatherData 
-    FROM WeatherData
-    ORDER BY id DESC`);
-  const events = select.all();
+  const events = store.getAllWeatherData();
 
   const sanitizedVersion = validator.escape(appVersion);
   response.render('owdebug', { events, version: sanitizedVersion });
@@ -370,8 +262,8 @@ app.get('/debug/weather', (request, response) => {
 
 // Debug route for update-check requests and per-device summaries.
 app.get('/debug/updates', (request, response) => {
-  const devices = summarizeUpdateChecks(selectUpdateChecksForSummary.all());
-  const recentChecks = selectRecentUpdateChecks.all().map((event) => ({
+  const devices = summarizeUpdateChecks(store.getUpdateChecksForSummary());
+  const recentChecks = store.getRecentUpdateChecks(500).map((event) => ({
     ...event,
     updateAvailable: Boolean(event.updateAvailable),
   }));
@@ -382,14 +274,7 @@ app.get('/debug/updates', (request, response) => {
 
 // Export route for downloading the event data as a CSV file.
 app.get('/export', (request, response) => {
-  const select = db.prepare(`
-    SELECT
-      saveDate,
-      vesselData,
-      ferryTempoData
-    FROM AppData
-    ORDER BY id DESC`);
-  const events = select.all();
+  const events = store.getAllAppData();
   if (!events || events.length === 0) {
     response.setHeader('Content-Type', 'text');
     response.status(204).send('No event data available.');
@@ -405,13 +290,7 @@ app.get('/export', (request, response) => {
 // Endpoint for fetching route data.
 app.get('/api/v1/route/:routeId', allowFerryTempoRouteCors, (request, response) => {
   const routeId = validator.escape(request.params.routeId);  // Escape HTML special characters
-  const select = db.prepare(`
-    SELECT 
-      saveDate,
-      ferryTempoData
-    FROM AppData
-    ORDER BY rowid DESC LIMIT 1`);
-  const result = select.get();
+  const result = store.getLatestAppData();
 
   // there is a slight chance that a call from a client could come in before we make the first calls to WSDOT, protect from that.
   if (result === undefined || result.ferryTempoData == null) {
@@ -455,13 +334,7 @@ app.get('/api/v1/route/:routeId', allowFerryTempoRouteCors, (request, response) 
 app.get('/api/v1/sun-times/:city', (request, response) => {
   let city = validator.escape(request.params.city).toLowerCase();  // Escape HTML special characters
   logger.debug(`Sun times request for city: ${city}`);
-  const select = db.prepare(`
-    SELECT 
-      saveDate,
-      weatherData
-    FROM WeatherData
-    ORDER BY rowid DESC LIMIT 1`);
-  const result = select.get();
+  const result = store.getLatestWeatherData();
   if (result === undefined || result.weatherData == null) {
     response.setHeader('Content-Type', 'text');
     response.writeHead(400);
@@ -653,13 +526,7 @@ app.get('/api/v1/update', (req, res) => {
 app.get('/api/v1/weather/:city', (req, res) => {
   let city = validator.escape(req.params.city).toLowerCase();  // Escape HTML special characters
   logger.debug(`Weather request for city: ${city}`);
-  const select = db.prepare(`
-    SELECT 
-      saveDate,
-      weatherData
-    FROM WeatherData
-    ORDER BY rowid DESC LIMIT 1`);
-  const result = select.get();
+  const result = store.getLatestWeatherData();
   if (result === undefined || result.weatherData == null) {
     res.setHeader('Content-Type', 'text');
     res.writeHead(400);
@@ -763,25 +630,7 @@ const fetchAndProcessData = () => {
             latestTerminalSailingSpaceData,
         );
 
-        // Create a row for the latest data.
-        const insert = db.prepare(`
-          INSERT INTO AppData (
-            saveDate,
-            vesselData,
-            ferryTempoData
-          ) VALUES (
-            unixepoch(),
-            json(?),
-            json(?)
-          )
-        `);
-        insert.run(JSON.stringify(vesselData), JSON.stringify(ferryTempoData));
-
-        // Purge any data beyond the expiration limit.
-        db.exec(`
-            DELETE from AppData
-            WHERE saveDate <= unixepoch('now', '-60 minutes')
-        `);
+        store.insertAppData(vesselData, ferryTempoData);
       })
       .catch((error) => logger.error(`WSDOT is returning: ${error}`));
 };
@@ -823,13 +672,7 @@ if ((ais_key == undefined) || (ais_key == 'undefined') || (ais_key == null)) {
             latestAisData = {};
           }
           latestAisData = aisData;
-          const select = db.prepare(`
-            SELECT 
-              saveDate,
-              ferryTempoData
-            FROM AppData
-            ORDER BY rowid DESC LIMIT 1`);
-          const result = select.get();
+          const result = store.getLatestAppData();
           if (result === undefined) {
             logger.warn('Cold start: no AppData available yet to compare AIS assignments.');
             return;
@@ -864,24 +707,7 @@ if ((weatherKey == undefined) || (weatherKey == 'undefined') || (weatherKey == n
     getOpenWeatherData()
         .then((openWeather) => {
           const weatherData = processOpenWeatherData(openWeather);
-          const insert = db.prepare(`
-            INSERT INTO WeatherData (
-              saveDate,
-              openWeather,
-              weatherData
-            ) VALUES (
-              unixepoch(),
-              json(?),
-              json(?)
-            )
-          `);
-          insert.run(JSON.stringify(openWeather), JSON.stringify(weatherData));
-
-          // Purge any data beyond the expiration limit.
-          db.exec(`
-              DELETE from WeatherData
-              WHERE saveDate <= unixepoch('now', '-60 minutes')
-          `);
+          store.insertWeatherData(openWeather, weatherData);
         })
         .catch((error) => {
           logger.error(`Weather data fetch error: ${error}`)

--- a/src/InMemoryStore.js
+++ b/src/InMemoryStore.js
@@ -1,0 +1,89 @@
+class InMemoryStore {
+  constructor() {
+    this.nextAppDataId = 1;
+    this.nextWeatherDataId = 1;
+    this.nextUpdateCheckId = 1;
+    this.appData = [];
+    this.weatherData = [];
+    this.updateChecks = [];
+  }
+
+  getNow() {
+    return Math.floor(Date.now() / 1000);
+  }
+
+  withoutId(event) {
+    if (!event) {
+      return undefined;
+    }
+
+    const { id, ...eventData } = event;
+    return eventData;
+  }
+
+  insertAppData(vesselData, ferryTempoData) {
+    this.appData.push({
+      id: this.nextAppDataId++,
+      saveDate: this.getNow(),
+      vesselData: JSON.stringify(vesselData),
+      ferryTempoData: JSON.stringify(ferryTempoData),
+    });
+    this.purgeAppDataBefore(this.getNow() - (60 * 60));
+  }
+
+  purgeAppDataBefore(expirationTime) {
+    this.appData = this.appData.filter((event) => event.saveDate > expirationTime);
+  }
+
+  getLatestAppData() {
+    return this.withoutId(this.appData[this.appData.length - 1]);
+  }
+
+  getRecentAppData(limit = 1000) {
+    return this.appData.toReversed().slice(0, limit).map((event) => this.withoutId(event));
+  }
+
+  getAllAppData() {
+    return this.appData.toReversed().map((event) => this.withoutId(event));
+  }
+
+  insertWeatherData(openWeather, weatherData) {
+    this.weatherData.push({
+      id: this.nextWeatherDataId++,
+      saveDate: this.getNow(),
+      openWeather: JSON.stringify(openWeather),
+      weatherData: JSON.stringify(weatherData),
+    });
+    this.purgeWeatherDataBefore(this.getNow() - (60 * 60));
+  }
+
+  purgeWeatherDataBefore(expirationTime) {
+    this.weatherData = this.weatherData.filter((event) => event.saveDate > expirationTime);
+  }
+
+  getLatestWeatherData() {
+    return this.withoutId(this.weatherData[this.weatherData.length - 1]);
+  }
+
+  getAllWeatherData() {
+    return this.weatherData.toReversed().map((event) => this.withoutId(event));
+  }
+
+  insertUpdateCheck(updateCheck) {
+    this.updateChecks.push({
+      id: this.nextUpdateCheckId++,
+      ...updateCheck,
+    });
+  }
+
+  getUpdateChecksForSummary() {
+    return this.updateChecks
+        .toSorted((first, second) => second.saveDate - first.saveDate || second.id - first.id);
+  }
+
+  getRecentUpdateChecks(limit = 500) {
+    return this.updateChecks.toReversed().slice(0, limit);
+  }
+}
+
+export default InMemoryStore;

--- a/src/RouteUtilities.js
+++ b/src/RouteUtilities.js
@@ -7,8 +7,8 @@ import { getCurrentEpochSeconds } from './Utils.js';
 
 const logger = new Logger();
 
-// Maximum amount of time a boat can be idle before we consider it to be off duty
-const MAX_IDLE_TIME = 60 * 60 * 1000; // 1 hour in milliseconds
+// Maximum seconds a boat can be idle before we consider it to be off duty.
+const MAX_IDLE_TIME = 60 * 60;
 
 //* Maximum speed a vessel can have and still be considered docked.
 const DOCKED_SPEED = 0.5;
@@ -39,6 +39,34 @@ const routeAssignments = initializeRouteAssignements();
 
 // variable used to lock access to the boat and assingment data to avoid concurent access
 let lockedForUpdate = false;
+
+function clearBoatAssignment(boat) {
+    if (!boat) {
+        return;
+    }
+
+    boat['AssignedRoute'] = '';
+    boat['AssignedPosition'] = '';
+    boat['AssignedSlot'] = -1;
+    boat['RouteConfirmed'] = false;
+}
+
+function clearRouteAssignment(route, slot) {
+    const assignment = routeAssignments[route]?.[slot];
+    if (!assignment) {
+        return;
+    }
+
+    const assignedBoat = boatData[assignment.MMSI];
+    assignment.MMSI = 0;
+    assignment.LatestUpdate = 0;
+    assignment.WeakAssignment = true;
+    assignment.IsAssigned = false;
+
+    if (assignedBoat?.AssignedRoute === route && assignedBoat?.AssignedSlot === slot) {
+        clearBoatAssignment(assignedBoat);
+    }
+}
 
 /**
  * Accepts AIS progress reports from aisstream.io and updates the
@@ -134,10 +162,8 @@ export function handleShipProgress(rawInfo) {
         if (distance > MAX_DISTANCE_FROM_ROUTE) {
             logger.info(`AIS: ${boat['VesselName']}: Too far from route ${boat['AssignedRoute']}, distance is ${Number(distance).toFixed(2)} nm`);
             // The ship is too far from the route. Dissociate it.
-            routeAssignments[boat['AssignedRoute']][boat['AssignedPosition']-1].IsAssigned = false;
-            boat['AssignedRoute'] = '';
-            boat['AssignedPosition'] = '';
-            boat['RouteConfirmed'] = false;
+            clearRouteAssignment(boat['AssignedRoute'], boat['AssignedSlot']);
+            clearBoatAssignment(boat);
             return;
         }
     }
@@ -254,19 +280,12 @@ export function assignToRoute(boat, routeAbbreviation, isConfirmed) {
         logger.debug(`${boat['VesselName']}: Reassigning from ${boat['AssignedRoute']} to ${routeAbbreviation}`);
         const oldRoute = boat['AssignedRoute'];
         const oldPos = boat['AssignedSlot'];
-        routeAssignments[oldRoute][oldPos].MMSI = 0;
-        routeAssignments[oldRoute][oldPos].LatestUpdate = 0;
-        routeAssignments[oldRoute][oldPos].WeakAssignment = true;
-        routeAssignments[oldRoute][oldPos].IsAssigned = false;
+        clearRouteAssignment(oldRoute, oldPos);
     }
 
     // if we used the "possible slot" we need to update the old boat data
     if (possiblePos != null) {
-        const oldBoat = boatData[assignment[possiblePos].MMSI];
-        oldBoat['AssignedRoute'] = '';
-        oldBoat['AssignedPosition'] = '';
-        oldBoat['AssignedSlot'] = -1;
-        oldBoat['RouteConfirmed'] = false;
+        clearRouteAssignment(routeAbbreviation, possiblePos);
     }    
     
     // update the slot data
@@ -651,10 +670,7 @@ export function updateAISData(wsdotData) {
                     // need to update the boat to remove old assignment, but only if the boat is assigned to this slot (it could have been updated already)
                     if (assignments[idx].MMSI !== 0 && boatData[assignments[idx].MMSI]['AssignedSlot'] === idx) {
                         logger.debug(`Removing old boat assignment for route ${route} at slot ${idx} for boat ${boatData[assignments[idx].MMSI]['VesselName']}`);
-                        boatData[assignments[idx].MMSI]['AssignedRoute'] = '';
-                        boatData[assignments[idx].MMSI]['AssignedPosition'] = '';
-                        boatData[assignments[idx].MMSI]['AssignedSlot'] = -1;
-                        boatData[assignments[idx].MMSI]['RouteConfirmed'] = false;
+                        clearRouteAssignment(route, idx);
                     }
                     assignments[idx].MMSI = positions[idx].MMSI;
                     assignments[idx].LatestUpdate = getCurrentEpochSeconds();
@@ -686,10 +702,7 @@ export function updateAISData(wsdotData) {
                 for (let idx = positions.length; idx < assignments.length; idx++) {
                     if (assignments[idx].MMSI !== 0) {
                         logger.debug(`Removing boat assignment for route ${route} at position ${idx+1} for boat ${boatData[assignments[idx].MMSI]['VesselName']}`);
-                        assignments[idx].MMSI = 0;
-                        assignments[idx].LatestUpdate = 0;
-                        assignments[idx].WeakAssignment = true;
-                        assignments[idx].IsAssigned = false;
+                        clearRouteAssignment(route, idx);
                     }
                 }
             }
@@ -709,4 +722,3 @@ export function updateAISData(wsdotData) {
     }
     lockedForUpdate = false;
 }
-

--- a/src/StorageManager.js
+++ b/src/StorageManager.js
@@ -20,12 +20,29 @@ class StorageManager {
      */
     getSailingDayId(epochSeconds = Math.floor(Date.now() / 1000)) {
         const sailingDayStartHour = 3;
-        const eventDate = new Date(epochSeconds * 1000);
-        eventDate.setHours(eventDate.getHours() - sailingDayStartHour);
-        const year = eventDate.getFullYear();
-        const month = String(eventDate.getMonth() + 1).padStart(2, '0');
-        const day = String(eventDate.getDate()).padStart(2, '0');
-        return `${year}-${month}-${day}`;
+        const timeZone = 'America/Los_Angeles';
+        const formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            hour12: false,
+        });
+        const localParts = formatter.formatToParts(new Date(epochSeconds * 1000));
+        const localPart = (type) => localParts.find((part) => part.type === type).value;
+        const localHour = Number(localPart('hour'));
+        const sailingDate = localHour < sailingDayStartHour ?
+            new Date(Date.UTC(Number(localPart('year')), Number(localPart('month')) - 1, Number(localPart('day')) - 1, 12)) :
+            new Date(Date.UTC(Number(localPart('year')), Number(localPart('month')) - 1, Number(localPart('day')), 12));
+        const dateParts = new Intl.DateTimeFormat('en-US', {
+            timeZone: 'America/Los_Angeles',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        }).formatToParts(sailingDate);
+        const datePart = (type) => dateParts.find((part) => part.type === type).value;
+        return `${datePart('year')}-${datePart('month')}-${datePart('day')}`;
     }
 
     /**

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -45,8 +45,8 @@ export function getEpochSecondsFromWSDOT(WSDOTDate) {
     return 0;
   }
 
-  // TODO: Check format of string to ensure compatibility https://github.com/FerryTempo/FTServer/issues/19
-  return parseInt(WSDOTDate.substring(WSDOTDate.lastIndexOf('(') + 1, WSDOTDate.lastIndexOf('-'))) / 1000;
+  const match = WSDOTDate.match(/^\/Date\((\d+)([-+]\d{4})\)\//);
+  return parseInt(match[1]) / 1000;
 }
 
 /**

--- a/test/RouteUtilities.test.js
+++ b/test/RouteUtilities.test.js
@@ -1,4 +1,14 @@
-import { getBoundingBoxes, getBoatMMSIList, dockedStatus, boatIsNearSeattle, initializeRouteAssignements, estimateRoute } from '../src/RouteUtilities';
+import {
+    getBoundingBoxes,
+    getBoatMMSIList,
+    dockedStatus,
+    boatIsNearSeattle,
+    initializeRouteAssignements,
+    estimateRoute,
+    getFTData,
+    updateAISData,
+} from '../src/RouteUtilities';
+import boatData from '../data/BoatData';
 
 describe('getBoundingBoxes function', () => {
     test('should return the set of bounding boxes for the ferry routes', () => {
@@ -140,5 +150,44 @@ describe('estimateRoute function', () => {
     });
     test('should return sea-bi since this is Bainbridge)', () => {
         expect(estimateRoute([47.622453, -122.509274])).toEqual(['sea-bi',0]);
+    });
+});
+
+describe('updateAISData function', () => {
+    test('clears boat assignment state when WSDOT removes an extra route slot', () => {
+        updateAISData({
+            'sea-bi': [
+                {MMSI: 366772760, Position: 1},
+                {MMSI: 366749710, Position: 2},
+            ],
+        });
+
+        expect(boatData['366749710']['AssignedRoute']).toBe('sea-bi');
+        expect(boatData['366749710']['AssignedPosition']).toBe(2);
+        expect(boatData['366749710']['AssignedSlot']).toBe(1);
+        expect(boatData['366749710']['RouteConfirmed']).toBe(true);
+
+        updateAISData({
+            'sea-bi': [
+                {MMSI: 366772760, Position: 1},
+            ],
+        });
+
+        expect(boatData['366749710']['AssignedRoute']).toBe('');
+        expect(boatData['366749710']['AssignedPosition']).toBe('');
+        expect(boatData['366749710']['AssignedSlot']).toBe(-1);
+        expect(boatData['366749710']['RouteConfirmed']).toBe(false);
+    });
+
+    test('marks AIS boats off duty after one idle hour in epoch seconds', () => {
+        updateAISData({
+            'sea-bi': [
+                {MMSI: 366772760, Position: 1},
+            ],
+        });
+
+        boatData['366772760']['LastMoveTime'] = Math.floor(Date.now() / 1000) - (60 * 60) - 1;
+
+        expect(getFTData()['sea-bi']['boatData']['boat1']['OnDuty']).toBe(false);
     });
 });

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -45,4 +45,12 @@ describe('StorageManager', () => {
 
         expect(storageManager.getDelay(key, sailingDayEpoch + 86400)).toBeNull();
     });
+
+    test('getSailingDayId uses America/Los_Angeles 3am sailing-day rollover', () => {
+        const beforeRollover = Date.UTC(2024, 2, 10, 9, 59, 0) / 1000;
+        const afterRollover = Date.UTC(2024, 2, 10, 10, 0, 0) / 1000;
+
+        expect(storageManager.getSailingDayId(beforeRollover)).toBe('2024-03-09');
+        expect(storageManager.getSailingDayId(afterRollover)).toBe('2024-03-10');
+    });
 });

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -50,6 +50,11 @@ describe('getEpochSecondsFromWSDOT function', () => {
     const WSDOTDate = '/Date(1713305248000-0700)/';
     expect(getEpochSecondsFromWSDOT(WSDOTDate)).toBe(1713305248);
   });
+
+  test('should return epoch seconds for positive timezone offsets', () => {
+    const WSDOTDate = '/Date(1713305248000+0000)/';
+    expect(getEpochSecondsFromWSDOT(WSDOTDate)).toBe(1713305248);
+  });
 });
 
 describe('getCurrentEpochSeconds function', () => {

--- a/views/debug.pug
+++ b/views/debug.pug
@@ -31,7 +31,7 @@ html(lang='en')
                 each event in events
                     tr
                         td 
-                            p #{new Date(event.saveDate * 1000).toLocaleString('en-US', { timeZone: 'PST'})} 
+                            p #{new Date(event.saveDate * 1000).toLocaleString('en-US', { timeZone: 'America/Los_Angeles'})} 
                             p (#{event.saveDate})
                         td
                             details

--- a/views/owdebug.pug
+++ b/views/owdebug.pug
@@ -31,7 +31,7 @@ html(lang='en')
                 each event in events
                     tr
                         td 
-                            p #{new Date(event.saveDate * 1000).toLocaleString('en-US', { timeZone: 'PST'})} 
+                            p #{new Date(event.saveDate * 1000).toLocaleString('en-US', { timeZone: 'America/Los_Angeles'})} 
                             p (#{event.saveDate})
                         td
                             details


### PR DESCRIPTION
Clear stale AIS boat assignment state whenever route slots are cleared so WSDOT removals and route-distance disassociations cannot leave a boat attached to an old route. Correct the AIS idle timeout to use epoch-second units, align sailing-day resets and debug timestamps to America/Los_Angeles, and parse WSDOT positive timezone offsets correctly. Replace the in-memory better-sqlite3 cache with a small process-local store so startup no longer depends on a native SQLite addon for non-persistent data.