### PR TITLE
Add cached reference schedules

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,13 +8,18 @@ import 'dotenv/config';
 import express from 'express';
 import Database from 'better-sqlite3';
 import {
+  fetchReferenceSailings,
+  fetchReferenceScheduleRoutes,
+  fetchScheduleCacheFlushDate,
   fetchScheduleData,
   fetchTerminalBulletinData,
   fetchTerminalSailingSpaceData,
   fetchVesselData,
 } from './WSDOT.js';
 import FerryTempo, { debugProgress } from './FerryTempo.js';
+import { buildReferenceSchedules, getActiveSchedRouteId } from './ReferenceSchedules.js';
 import Logger from './Logger.js';
+import routeFTData from '../data/RouteFTData.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -31,6 +36,7 @@ const PORT = process.env.PORT || 8080;
 const app = express();
 const fetchInterval = 5000;
 const scheduleFetchInterval = 600000;
+const referenceScheduleFetchInterval = 86400000;
 const terminalBulletinFetchInterval = 600000;
 const terminalSailingSpaceFetchInterval = 5000;
 const appVersion = process.env.npm_package_version;
@@ -39,6 +45,9 @@ let latestAisData = null;
 let latestScheduleData = null;
 let latestScheduleTripDate = null;
 let scheduleFetchInFlight = false;
+let latestReferenceSchedules = null;
+let latestReferenceScheduleCacheFlushDate = null;
+let referenceScheduleFetchInFlight = false;
 let latestTerminalBulletinData = null;
 let terminalBulletinFetchInFlight = false;
 let latestTerminalSailingSpaceData = null;
@@ -403,6 +412,38 @@ app.get('/export', (request, response) => {
 });
 
 // Endpoint for fetching route data.
+app.get('/api/v1/route/:routeId/reference-schedule', allowFerryTempoRouteCors, (request, response) => {
+  const routeId = validator.escape(request.params.routeId);
+  if (!routeFTData.hasOwnProperty(routeId)) {
+    response.setHeader('Content-Type', 'text');
+    response.writeHead(400);
+    response.end(`Unknown route requested: ${routeId}`);
+    return;
+  }
+
+  if (!latestReferenceSchedules) {
+    response.setHeader('Content-Type', 'text');
+    response.writeHead(503);
+    response.end(`No reference schedule available for route: ${routeId}`);
+    return;
+  }
+
+  const referenceSchedule = latestReferenceSchedules[routeId];
+  if (!referenceSchedule) {
+    response.setHeader('Content-Type', 'text');
+    response.writeHead(404);
+    response.end(`No reference schedule found for route: ${routeId}`);
+    return;
+  }
+
+  response.setHeader('Content-Type', 'application/json');
+  response.writeHead(200);
+  response.end(JSON.stringify({
+    ...referenceSchedule,
+    serverVersion: appVersion,
+  }));
+});
+
 app.get('/api/v1/route/:routeId', allowFerryTempoRouteCors, (request, response) => {
   const routeId = validator.escape(request.params.routeId);  // Escape HTML special characters
   const select = db.prepare(`
@@ -715,6 +756,52 @@ const fetchScheduleDataForCurrentSailingDay = () => {
       });
 };
 
+const fetchReferenceScheduleDataForRoutes = () => {
+  if (referenceScheduleFetchInFlight) {
+    return;
+  }
+
+  referenceScheduleFetchInFlight = true;
+  const fetchedAt = Math.floor(Date.now() / 1000);
+  Promise.all([
+    fetchReferenceScheduleRoutes(),
+    fetchScheduleCacheFlushDate(),
+  ])
+      .then(([schedRoutes, cacheFlushDate]) => {
+        if (latestReferenceSchedules && latestReferenceScheduleCacheFlushDate === cacheFlushDate) {
+          return null;
+        }
+
+        const schedRouteIds = new Set();
+        for (const routeData of Object.values(routeFTData)) {
+          const schedRoute = schedRoutes.find((candidate) => {
+            return String(candidate.RouteID) === String(routeData.routeID) && !candidate.ContingencyOnly;
+          });
+          if (schedRoute) {
+            schedRouteIds.add(getActiveSchedRouteId(schedRoute, fetchedAt));
+          }
+        }
+
+        return Promise.all(Array.from(schedRouteIds).map((schedRouteId) => {
+          return fetchReferenceSailings(schedRouteId)
+              .then((sailings) => [schedRouteId, sailings]);
+        })).then((routeSailings) => {
+          latestReferenceSchedules = buildReferenceSchedules(
+              schedRoutes,
+              Object.fromEntries(routeSailings),
+              cacheFlushDate,
+              fetchedAt,
+          );
+          latestReferenceScheduleCacheFlushDate = cacheFlushDate;
+          return latestReferenceSchedules;
+        });
+      })
+      .catch((error) => logger.error(`WSDOT reference schedules are returning: ${error}`))
+      .finally(() => {
+        referenceScheduleFetchInFlight = false;
+      });
+};
+
 const fetchTerminalBulletinDataForPorts = () => {
   if (terminalBulletinFetchInFlight) {
     return;
@@ -789,6 +876,10 @@ const fetchAndProcessData = () => {
 logger.info(`Fetching schedule data every ${scheduleFetchInterval / 1000} seconds.`);
 fetchScheduleDataForCurrentSailingDay();
 setInterval(fetchScheduleDataForCurrentSailingDay, scheduleFetchInterval);
+
+logger.info(`Fetching reference schedule data every ${referenceScheduleFetchInterval / 1000} seconds.`);
+fetchReferenceScheduleDataForRoutes();
+setInterval(fetchReferenceScheduleDataForRoutes, referenceScheduleFetchInterval);
 
 logger.info(`Fetching terminal bulletin data every ${terminalBulletinFetchInterval / 1000} seconds.`);
 fetchTerminalBulletinDataForPorts();

--- a/src/ReferenceSchedules.js
+++ b/src/ReferenceSchedules.js
@@ -1,0 +1,137 @@
+import routeFTData from '../data/RouteFTData.js';
+
+const WSF_TIME_ZONE = 'America/Los_Angeles';
+
+function getWSDOTMilliseconds(dateString) {
+  if (!dateString) {
+    return null;
+  }
+
+  const match = dateString.match(/^\/Date\((-?\d+)([-+]\d{4})\)\//);
+  return match ? Number(match[1]) : null;
+}
+
+export function getEpochSecondsFromReferenceDate(dateString) {
+  const milliseconds = getWSDOTMilliseconds(dateString);
+  return milliseconds === null ? null : milliseconds / 1000;
+}
+
+export function getReferenceTimeDisplay(dateString) {
+  const milliseconds = getWSDOTMilliseconds(dateString);
+  if (milliseconds === null) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: WSF_TIME_ZONE,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(milliseconds));
+}
+
+function normalizeActiveDateRange(activeDateRange) {
+  return {
+    DateFrom: getEpochSecondsFromReferenceDate(activeDateRange.DateFrom),
+    DateThru: getEpochSecondsFromReferenceDate(activeDateRange.DateThru),
+    EventID: activeDateRange.EventID,
+    EventDescription: activeDateRange.EventDescription,
+  };
+}
+
+function normalizeTerminalTime(terminalTime) {
+  return {
+    JourneyTerminalID: terminalTime.JourneyTerminalID,
+    TerminalID: terminalTime.TerminalID,
+    TerminalDescription: terminalTime.TerminalDescription,
+    TerminalBriefDescription: terminalTime.TerminalBriefDescription,
+    Time: terminalTime.Time,
+    TimeDisplay: getReferenceTimeDisplay(terminalTime.Time),
+    DepArrIndicator: terminalTime.DepArrIndicator,
+    IsNA: terminalTime.IsNA,
+    Annotations: terminalTime.Annotations || [],
+  };
+}
+
+function normalizeJourney(journey) {
+  return {
+    JourneyID: journey.JourneyID,
+    ReservationInd: journey.ReservationInd,
+    InternationalInd: journey.InternationalInd,
+    InterislandInd: journey.InterislandInd,
+    VesselID: journey.VesselID,
+    VesselName: journey.VesselName,
+    VesselHandicapAccessible: journey.VesselHandicapAccessible,
+    VesselPositionNum: journey.VesselPositionNum,
+    TerminalTimes: (journey.TerminalTimes || []).map(normalizeTerminalTime),
+  };
+}
+
+function normalizeSailing(sailing) {
+  return {
+    ScheduleID: sailing.ScheduleID,
+    SchedRouteID: sailing.SchedRouteID,
+    RouteID: sailing.RouteID,
+    SailingID: sailing.SailingID,
+    SailingDescription: sailing.SailingDescription,
+    SailingNotes: sailing.SailingNotes,
+    DisplayColNum: sailing.DisplayColNum,
+    SailingDir: sailing.SailingDir,
+    DayOpDescription: sailing.DayOpDescription,
+    DayOpUseForHoliday: sailing.DayOpUseForHoliday,
+    ActiveDateRanges: (sailing.ActiveDateRanges || []).map(normalizeActiveDateRange),
+    Journs: (sailing.Journs || []).map(normalizeJourney),
+  };
+}
+
+export function getActiveSchedRouteId(schedRoute, referenceEpochSeconds) {
+  const activeContingency = (schedRoute.ContingencyAdj || []).find((contingency) => {
+    if (!contingency.ReplacedBySchedRouteID) {
+      return false;
+    }
+
+    const dateFrom = getEpochSecondsFromReferenceDate(contingency.DateFrom);
+    const dateThru = getEpochSecondsFromReferenceDate(contingency.DateThru);
+    return dateFrom !== null && dateThru !== null &&
+      referenceEpochSeconds >= dateFrom &&
+      referenceEpochSeconds <= dateThru;
+  });
+
+  return activeContingency?.ReplacedBySchedRouteID || schedRoute.SchedRouteID;
+}
+
+export function buildReferenceSchedules(schedRoutes, sailingsBySchedRouteId, cacheFlushDate, fetchedAt) {
+  const schedulesByRoute = {};
+
+  for (const [routeAbbreviation, routeData] of Object.entries(routeFTData)) {
+    const schedRoute = schedRoutes.find((candidate) => {
+      return String(candidate.RouteID) === String(routeData.routeID) && !candidate.ContingencyOnly;
+    });
+    if (!schedRoute) {
+      continue;
+    }
+
+    const activeSchedRouteId = getActiveSchedRouteId(schedRoute, fetchedAt);
+    const sailings = sailingsBySchedRouteId[activeSchedRouteId] || [];
+    schedulesByRoute[routeAbbreviation] = {
+      routeId: routeAbbreviation,
+      RouteID: schedRoute.RouteID,
+      RouteAbbrev: schedRoute.RouteAbbrev,
+      Description: schedRoute.Description,
+      ScheduleID: schedRoute.ScheduleID,
+      SchedRouteID: activeSchedRouteId,
+      BaseSchedRouteID: schedRoute.SchedRouteID,
+      SeasonalRouteNotes: schedRoute.SeasonalRouteNotes,
+      ServiceDisruptions: schedRoute.ServiceDisruptions || [],
+      ContingencyAdj: schedRoute.ContingencyAdj || [],
+      CacheFlushDate: cacheFlushDate,
+      CacheFlushDateEpoch: getEpochSecondsFromReferenceDate(cacheFlushDate),
+      fetchedAt,
+      SailingGroups: sailings
+          .map(normalizeSailing)
+          .sort((first, second) => first.DisplayColNum - second.DisplayColNum),
+    };
+  }
+
+  return schedulesByRoute;
+}

--- a/src/WSDOT.js
+++ b/src/WSDOT.js
@@ -35,6 +35,18 @@ export const fetchScheduleData = async function(tripDate) {
   return Object.fromEntries(routeSchedules);
 };
 
+export const fetchReferenceScheduleRoutes = async function() {
+  return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/schedule/rest/schedroutes?apiaccesscode=${process.env.WSDOT_API_KEY}`);
+};
+
+export const fetchReferenceSailings = async function(schedRouteId) {
+  return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/schedule/rest/sailings/${schedRouteId}?apiaccesscode=${process.env.WSDOT_API_KEY}`);
+};
+
+export const fetchScheduleCacheFlushDate = async function() {
+  return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/schedule/rest/cacheflushdate?apiaccesscode=${process.env.WSDOT_API_KEY}`);
+};
+
 export const fetchTerminalBulletinData = async function() {
   return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/terminals/rest/terminalbulletins?apiaccesscode=${process.env.WSDOT_API_KEY}`);
 };

--- a/test/ReferenceSchedules.test.js
+++ b/test/ReferenceSchedules.test.js
@@ -1,0 +1,121 @@
+import {
+  buildReferenceSchedules,
+  getActiveSchedRouteId,
+  getEpochSecondsFromReferenceDate,
+  getReferenceTimeDisplay,
+} from '../src/ReferenceSchedules.js';
+
+function wsdotDate(epochSeconds) {
+  return `/Date(${epochSeconds * 1000}-0700)/`;
+}
+
+describe('ReferenceSchedules', () => {
+  test('formats WSDOT reference sailing time-of-day values', () => {
+    expect(getReferenceTimeDisplay('/Date(-2208940200000-0800)/')).toBe('05:30');
+  });
+
+  test('parses WSDOT reference dates with positive and negative epoch values', () => {
+    expect(getEpochSecondsFromReferenceDate(wsdotDate(1774162800))).toBe(1774162800);
+    expect(getEpochSecondsFromReferenceDate('/Date(-2208940200000-0800)/')).toBe(-2208940200);
+  });
+
+  test('uses active contingency schedule route IDs when a date range applies', () => {
+    const schedRoute = {
+      SchedRouteID: 2434,
+      ContingencyAdj: [
+        {
+          DateFrom: wsdotDate(1774162800),
+          DateThru: wsdotDate(1775296740),
+          ReplacedBySchedRouteID: 2441,
+        },
+      ],
+    };
+
+    expect(getActiveSchedRouteId(schedRoute, 1775000000)).toBe(2441);
+    expect(getActiveSchedRouteId(schedRoute, 1776000000)).toBe(2434);
+  });
+
+  test('builds route-keyed reference schedule groups', () => {
+    const schedules = buildReferenceSchedules(
+        [
+          {
+            ScheduleID: 195,
+            SchedRouteID: 2435,
+            ContingencyOnly: false,
+            RouteID: 5,
+            RouteAbbrev: 'sea-bi',
+            Description: 'Seattle / Bainbridge Island',
+            SeasonalRouteNotes: 'Season note',
+            ServiceDisruptions: [],
+            ContingencyAdj: [],
+          },
+        ],
+        {
+          2435: [
+            {
+              ScheduleID: 195,
+              SchedRouteID: 2435,
+              RouteID: 5,
+              SailingID: 7963,
+              SailingDescription: 'Leave Seattle',
+              SailingNotes: '',
+              DisplayColNum: 4,
+              SailingDir: 1,
+              DayOpDescription: 'Monday through Friday',
+              DayOpUseForHoliday: false,
+              ActiveDateRanges: [
+                {
+                  DateFrom: wsdotDate(1774162800),
+                  DateThru: wsdotDate(1781334000),
+                },
+              ],
+              Journs: [
+                {
+                  JourneyID: 169540,
+                  ReservationInd: false,
+                  InternationalInd: false,
+                  InterislandInd: false,
+                  VesselID: 37,
+                  VesselName: 'Wenatchee',
+                  VesselHandicapAccessible: true,
+                  VesselPositionNum: 1,
+                  TerminalTimes: [
+                    {
+                      JourneyTerminalID: 241736,
+                      TerminalID: 7,
+                      TerminalDescription: 'Seattle',
+                      TerminalBriefDescription: 'Colman P52',
+                      Time: '/Date(-2208940200000-0800)/',
+                      DepArrIndicator: 1,
+                      IsNA: false,
+                      Annotations: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        wsdotDate(1777334400),
+        1777334500,
+    );
+
+    expect(schedules['sea-bi']).toMatchObject({
+      routeId: 'sea-bi',
+      RouteID: 5,
+      Description: 'Seattle / Bainbridge Island',
+      SchedRouteID: 2435,
+      BaseSchedRouteID: 2435,
+      CacheFlushDateEpoch: 1777334400,
+      fetchedAt: 1777334500,
+    });
+    expect(schedules['sea-bi'].SailingGroups[0]).toMatchObject({
+      SailingDescription: 'Leave Seattle',
+      DayOpDescription: 'Monday through Friday',
+    });
+    expect(schedules['sea-bi'].SailingGroups[0].Journs[0].TerminalTimes[0]).toMatchObject({
+      TerminalID: 7,
+      TimeDisplay: '05:30',
+    });
+  });
+});


### PR DESCRIPTION
Expose an app-facing /api/v1/route/:routeId/reference-schedule endpoint backed by WSDOT schedroutes, sailings, and cacheflushdate data. Cache the printed-schedule style data on startup and refresh daily, skipping sailing refetches while WSDOT's cache flush date is unchanged. Normalize schedules into route-keyed weekday/weekend/holiday sailing groups with readable time displays while preserving raw WSF metadata and handling active contingency SchedRouteID replacements.