### PR TITLE
Simplify port sailing logs

### DIFF
--- a/schemas/FerryTempo.schema.json
+++ b/schemas/FerryTempo.schema.json
@@ -166,39 +166,22 @@
 					}
 				},
 				"PortSailingLog": {
-					"description": "Observed departures for the current sailing day with actual left-dock delay in seconds.",
+					"description": "Scheduled departures for the current sailing day paired with observed departure delay in seconds, or null when not yet observed.",
 					"type": "array",
 					"items": {
-						"type": "object",
-						"properties": {
-							"ScheduledDeparture": {
+						"type": "array",
+						"prefixItems": [
+							{
 								"description": "Scheduled departure epoch seconds.",
 								"type": "integer"
 							},
-							"LeftDock": {
-								"description": "Actual left-dock epoch seconds.",
-								"type": "integer"
-							},
-							"DepartureDelay": {
-								"description": "Seconds late or early relative to the scheduled departure.",
-								"type": "integer"
-							},
-							"VesselID": {
-								"description": "WSF vessel identifier.",
-								"type": "integer"
-							},
-							"VesselName": {
-								"description": "WSF vessel name.",
-								"type": "string"
+							{
+								"description": "Observed departure delay in seconds, or null when the departure has not been observed.",
+								"type": ["integer", "null"]
 							}
-						},
-						"required": [
-							"ScheduledDeparture",
-							"LeftDock",
-							"DepartureDelay",
-							"VesselID",
-							"VesselName"
-						]
+						],
+						"minItems": 2,
+						"maxItems": 2
 					}
 				},
 				"PortDepartureDelay": {

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -10,7 +10,7 @@ import {
   getProgress, 
   updateAverage, 
   getAverage, 
-  recordSailingLogEntry,
+  recordSailingDepartureDelay,
   getSailingLog,
   getSailingDayId,
   getRouteFromTerminals 
@@ -448,17 +448,12 @@ export default {
             boatArrivalCache[VesselName] = epochTimeStamp;
           }
         } else {
-          if (epochLeftDock && epochScheduledDeparture) {
-            recordSailingLogEntry(
+          if (epochScheduledDeparture && delayEventTime) {
+            recordSailingDepartureDelay(
                 portDelayCacheKey,
-                {
-                  ScheduledDeparture: epochScheduledDeparture,
-                  LeftDock: epochLeftDock,
-                  DepartureDelay: boatDelay,
-                  VesselID,
-                  VesselName,
-                },
-                epochLeftDock,
+                epochScheduledDeparture,
+                boatDelay,
+                delayEventTime,
             );
           }
 
@@ -576,10 +571,6 @@ export default {
         if (cachedPortDelay !== null) {
           updatedFerryTempoData[routeAbbreviation]['portData'][portKey].PortDepartureDelay = cachedPortDelay;
         }
-        updatedFerryTempoData[routeAbbreviation]['portData'][portKey].PortSailingLog = getSailingLog(
-            cacheKey,
-            latestEventTime || getCurrentEpochSeconds(),
-        );
       }
     }
 
@@ -589,6 +580,16 @@ export default {
         latestEventTime || getCurrentEpochSeconds(),
         activeScheduledDepartureCandidates,
     );
+    for (const routeAbbreviation in updatedFerryTempoData) {
+      for (const portKey of ['portWN', 'portES']) {
+        const portData = updatedFerryTempoData[routeAbbreviation]['portData'][portKey];
+        portData.PortSailingLog = getSailingLog(
+            getPortDelayCacheKey(routeAbbreviation, portKey),
+            portData.PortScheduleList,
+            latestEventTime || getCurrentEpochSeconds(),
+        );
+      }
+    }
     applyTerminalBulletinData(updatedFerryTempoData, terminalBulletinData);
     applyTerminalSailingSpaceData(
         updatedFerryTempoData,

--- a/src/StorageManager.js
+++ b/src/StorageManager.js
@@ -78,47 +78,50 @@ class StorageManager {
     }
 
     /**
-     * Add a single observed sailing departure to the current sailing-day log.
+     * Record the observed delay for a scheduled departure in the current sailing-day log.
      * @param key Identifier for the port log.
-     * @param entry Sailing log entry.
+     * @param scheduledDeparture Scheduled departure epoch seconds.
+     * @param departureDelay Departure delay in seconds.
      * @param epochSeconds Event time used to scope data to a WSF sailing day.
-     * @return {Array} Current sailing log entries for the key.
      */
-    addSailingLogEntry(key, entry, epochSeconds) {
+    setSailingDepartureDelay(key, scheduledDeparture, departureDelay, epochSeconds) {
         const sailingDayId = this.getSailingDayId(epochSeconds);
         this.clearStaleDelayData(sailingDayId);
         if (!this.sailingLogStorage[key] || this.sailingLogStorage[key].sailingDayId !== sailingDayId) {
             this.sailingLogStorage[key] = {
                 sailingDayId,
-                entries: [],
-                entryIds: {},
+                departureDelays: {},
             };
         }
 
-        const entryId = `${entry.ScheduledDeparture}`;
-        if (!this.sailingLogStorage[key].entryIds[entryId]) {
-            this.sailingLogStorage[key].entries.push(entry);
-            this.sailingLogStorage[key].entries.sort((first, second) => first.ScheduledDeparture - second.ScheduledDeparture);
-            this.sailingLogStorage[key].entryIds[entryId] = true;
-        }
-
-        return this.sailingLogStorage[key].entries;
+        this.sailingLogStorage[key].departureDelays[scheduledDeparture] = departureDelay;
     }
 
     /**
-     * Get the current sailing-day departure log for a port.
+     * Get the current sailing-day departure log for a port as [ScheduledDeparture, DepartureDelay] pairs.
      * @param key Identifier for the port log.
+     * @param scheduleList Scheduled departures for the port.
      * @param epochSeconds Event time used to scope data to a WSF sailing day.
      * @return {Array} Sailing log entries.
      */
-    getSailingLog(key, epochSeconds) {
+    getSailingLog(key, scheduleList = [], epochSeconds) {
         const sailingDayId = this.getSailingDayId(epochSeconds);
         this.clearStaleDelayData(sailingDayId);
-        if (this.sailingLogStorage[key] && this.sailingLogStorage[key].sailingDayId === sailingDayId) {
-            return this.sailingLogStorage[key].entries;
+        const departureDelays =
+            this.sailingLogStorage[key]?.sailingDayId === sailingDayId ?
+            this.sailingLogStorage[key].departureDelays :
+            {};
+
+        if (scheduleList.length > 0) {
+            return scheduleList.map((scheduledDeparture) => [
+                scheduledDeparture,
+                departureDelays.hasOwnProperty(scheduledDeparture) ? departureDelays[scheduledDeparture] : null,
+            ]);
         }
 
-        return [];
+        return Object.entries(departureDelays)
+            .map(([scheduledDeparture, departureDelay]) => [Number(scheduledDeparture), departureDelay])
+            .sort((first, second) => first[0] - second[0]);
     }
 }
 export default StorageManager;

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -284,24 +284,30 @@ export function getAverage(key, epochSeconds = getCurrentEpochSeconds()) {
 }
 
 /**
- * Record a single observed departure in a port's current sailing-day log.
+ * Record the observed delay for a scheduled departure in a port's current sailing-day log.
  * @param key Port log identifier.
- * @param entry Sailing log entry.
+ * @param scheduledDeparture Scheduled departure epoch seconds.
+ * @param departureDelay Departure delay in seconds.
  * @param epochSeconds Event time used to scope data to a WSF sailing day.
- * @return {Array} Current sailing log entries.
  */
-export function recordSailingLogEntry(key, entry, epochSeconds = getCurrentEpochSeconds()) {
-  return storage.addSailingLogEntry(key, entry, epochSeconds);
+export function recordSailingDepartureDelay(
+    key,
+    scheduledDeparture,
+    departureDelay,
+    epochSeconds = getCurrentEpochSeconds(),
+) {
+  storage.setSailingDepartureDelay(key, scheduledDeparture, departureDelay, epochSeconds);
 }
 
 /**
  * Get a port's current sailing-day departure log.
  * @param key Port log identifier.
+ * @param scheduleList Scheduled departures for the port.
  * @param epochSeconds Event time used to scope data to a WSF sailing day.
  * @return {Array} Current sailing log entries.
  */
-export function getSailingLog(key, epochSeconds = getCurrentEpochSeconds()) {
-  return storage.getSailingLog(key, epochSeconds);
+export function getSailingLog(key, scheduleList = [], epochSeconds = getCurrentEpochSeconds()) {
+  return storage.getSailingLog(key, scheduleList, epochSeconds);
 }
 
 /**

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -181,8 +181,22 @@ describe('FerryTempo.processFerryData', () => {
     expect(ferryTempoData['ed-king']['portData']['portWN']['PortArrivalTimeMinus']).toBe(2000);
   });
 
-  test('records each observed departure once in the port sailing log', () => {
+  test('annotates the port sailing log with observed departure delays', () => {
     const eastPoint = routePositionData['ed-king'][routePositionData['ed-king'].length - 1];
+    const scheduleData = {
+      'ed-king': {
+        TerminalCombos: [
+          {
+            DepartingTerminalID: 8,
+            ArrivingTerminalID: 12,
+            Times: [
+              { DepartingTime: wsdotDate(1710700000) },
+              { DepartingTime: wsdotDate(1710701800) },
+            ],
+          },
+        ],
+      },
+    };
     const vessel = buildVessel({
       VesselID: 11,
       VesselName: 'Sailing Log Boat',
@@ -196,17 +210,12 @@ describe('FerryTempo.processFerryData', () => {
       ScheduledDeparture: wsdotDate(1710700000),
     });
 
-    FerryTempo.processFerryData([vessel]);
-    const repeatedCycle = FerryTempo.processFerryData([vessel]);
+    FerryTempo.processFerryData([vessel], scheduleData);
+    const repeatedCycle = FerryTempo.processFerryData([vessel], scheduleData);
 
     expect(repeatedCycle['ed-king']['portData']['portES']['PortSailingLog']).toEqual([
-      {
-        ScheduledDeparture: 1710700000,
-        LeftDock: 1710700060,
-        DepartureDelay: 60,
-        VesselID: 11,
-        VesselName: 'Sailing Log Boat',
-      },
+      [1710700000, 60],
+      [1710701800, null],
     ]);
   });
 

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -46,20 +46,20 @@ describe('StorageManager', () => {
         expect(storageManager.getDelay(key, sailingDayEpoch + 86400)).toBeNull();
     });
 
-    test('sailing log entries are deduplicated and reset by sailing day', () => {
+    test('sailing log annotates scheduled departures and resets by sailing day', () => {
         const key = 'ed-king:portES';
-        const entry = {
-            ScheduledDeparture: sailingDayEpoch,
-            LeftDock: sailingDayEpoch + 60,
-            DepartureDelay: 60,
-            VesselID: 1,
-            VesselName: 'Test Boat',
-        };
+        const scheduleList = [sailingDayEpoch, sailingDayEpoch + 1800];
 
-        storageManager.addSailingLogEntry(key, entry, sailingDayEpoch);
-        storageManager.addSailingLogEntry(key, entry, sailingDayEpoch);
+        storageManager.setSailingDepartureDelay(key, sailingDayEpoch, 60, sailingDayEpoch + 60);
+        storageManager.setSailingDepartureDelay(key, sailingDayEpoch, 60, sailingDayEpoch + 60);
 
-        expect(storageManager.getSailingLog(key, sailingDayEpoch)).toEqual([entry]);
-        expect(storageManager.getSailingLog(key, sailingDayEpoch + 86400)).toEqual([]);
+        expect(storageManager.getSailingLog(key, scheduleList, sailingDayEpoch)).toEqual([
+            [sailingDayEpoch, 60],
+            [sailingDayEpoch + 1800, null],
+        ]);
+        expect(storageManager.getSailingLog(key, scheduleList, sailingDayEpoch + 86400)).toEqual([
+            [sailingDayEpoch, null],
+            [sailingDayEpoch + 1800, null],
+        ]);
     });
 });


### PR DESCRIPTION
Change PortSailingLog from verbose observed departure objects to compact [ScheduledDeparture, DepartureDelay] pairs aligned to PortScheduleList order, using null for unobserved departures. Store only the daily scheduled-departure delay map in memory, continue resetting with the WSF sailing day, and keep the log omitted from hardware cid responses. Update schema and tests for the compact format.