### PR TITLE
Keep next scheduled departure in schedule list

### DIFF
--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -94,8 +94,9 @@ function applyScheduleData(ferryTempoData, scheduleData, referenceTime, activeSc
       portData.PortScheduleList = scheduleList;
       const scheduleCandidate = scheduleList.find((departingTime) => departingTime >= referenceTime) ?? null;
       const activeCandidate = activeScheduledDepartureCandidates[getPortDelayCacheKey(routeAbbreviation, portKey)];
+      const activeCandidateInScheduleList = scheduleList.includes(activeCandidate);
       const nextAfterActiveCandidate = scheduleList.find((departingTime) => departingTime > activeCandidate);
-      const activeCandidateIsCurrent = activeCandidate &&
+      const activeCandidateIsCurrent = activeCandidateInScheduleList &&
           (!nextAfterActiveCandidate || referenceTime < nextAfterActiveCandidate);
 
       portData.NextScheduledDeparture = activeCandidateIsCurrent ? activeCandidate : scheduleCandidate;

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -338,6 +338,41 @@ describe('FerryTempo.processFerryData', () => {
     expect(ferryTempoData['ed-king']['portData']['portES']['NextScheduledDeparture']).toBe(1710403600);
   });
 
+  test('does not use an active scheduled departure outside the port schedule list', () => {
+    const scheduleData = {
+      'ed-king': {
+        TerminalCombos: [
+          {
+            DepartingTerminalID: 8,
+            ArrivingTerminalID: 12,
+            Times: [
+              { DepartingTime: wsdotDate(1710410000) },
+              { DepartingTime: wsdotDate(1710411800) },
+            ],
+          },
+        ],
+      },
+    };
+
+    const ferryTempoData = FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 12,
+        VesselName: 'Mismatched Schedule Boat',
+        Mmsi: 121212121,
+        AtDock: true,
+        LeftDock: null,
+        TimeStamp: wsdotDate(1710409000),
+        ScheduledDeparture: wsdotDate(1710400000),
+      }),
+    ], scheduleData);
+
+    expect(ferryTempoData['ed-king']['portData']['portES']['PortScheduleList']).toEqual([
+      1710410000,
+      1710411800,
+    ]);
+    expect(ferryTempoData['ed-king']['portData']['portES']['NextScheduledDeparture']).toBe(1710410000);
+  });
+
   test('adds terminal alerts and vehicle spaces to port data', () => {
     const scheduleData = {
       'ed-king': {


### PR DESCRIPTION
Require the active vessel scheduled departure override to match an entry in the port's current PortScheduleList before using it as NextScheduledDeparture. This preserves late-boat handling for valid schedule slots while preventing stale or cross-day WSF vessel timestamps from pointing outside the day's schedule list.

Add a regression test for a vessel-reported scheduled departure that is not present in the current port schedule list.