### PR TITLE
Add route-level WSF alerts

### DIFF
--- a/data/RouteFTData.js
+++ b/data/RouteFTData.js
@@ -2,6 +2,7 @@ export default {
   'pt-cou': {
     'boatData': {},
     'routeID': '8',
+    'RouteAlerts': [],
     'portData': {
       'portWN': {
         'TerminalName': 'Port Townsend',
@@ -38,6 +39,7 @@ export default {
   'muk-cl': {
     'boatData': {},
     'routeID': '7',
+    'RouteAlerts': [],
     'portData': {
       'portWN': {
         'TerminalName': 'Clinton',
@@ -74,6 +76,7 @@ export default {
   'ed-king': {
     'boatData': {},
     'routeID': '6',
+    'RouteAlerts': [],
     'portData': {
       'portWN': {
         'TerminalName': 'Kingston',
@@ -110,6 +113,7 @@ export default {
   'sea-bi': {
     'boatData': {},
     'routeID': '5',
+    'RouteAlerts': [],
     'portData': {
       'portWN': {
         'TerminalName': 'Bainbridge Island',
@@ -146,6 +150,7 @@ export default {
   'sea-br': {
     'boatData': {},
     'routeID': '3',
+    'RouteAlerts': [],
     'portData': {
       'portWN': {
         'TerminalName': 'Bremerton',

--- a/schemas/FerryTempo.schema.json
+++ b/schemas/FerryTempo.schema.json
@@ -216,6 +216,58 @@
 				"PortETA",
 				"PortArrivalTimeMinus"
 			]
+		},
+		"singleRouteAlert": {
+			"title": "Ferry Tempo Route Alert",
+			"description": "Route-level alert from WSF schedule alerts or duplicated terminal bulletins promoted to the route.",
+			"type": "object",
+			"properties": {
+				"Title": {
+					"type": "string"
+				},
+				"Text": {
+					"type": "string"
+				},
+				"Html": {
+					"type": "string"
+				},
+				"Source": {
+					"type": "string"
+				},
+				"PublishDate": {
+					"type": "integer"
+				},
+				"LastUpdated": {
+					"type": "integer"
+				},
+				"AffectedRouteIDs": {
+					"type": "array",
+					"items": {
+						"type": "integer"
+					}
+				},
+				"TerminalIDs": {
+					"type": "array",
+					"items": {
+						"type": "integer"
+					}
+				},
+				"RouteAlertFlag": {
+					"type": "boolean"
+				},
+				"BulletinFlag": {
+					"type": "boolean"
+				},
+				"CommunicationFlag": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"Title",
+				"Text",
+				"Html",
+				"Source"
+			]
 		}
 	},
 	"$id": "https://www.ferrytempo.com/schemas/FerryTempo.schema.json",
@@ -256,6 +308,14 @@
 				"portES"
 			]
 		},
+		"RouteAlerts": {
+			"title": "Ferry Tempo Route Alerts",
+			"description": "Route-level alerts that apply to both terminals or to the route as a whole.",
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/singleRouteAlert"
+			}
+		},
 		"lastUpdate": {
 			"description": "Date/time in epoch seconds of the last Ferry Tempo data update.",
 			"type": "integer"
@@ -268,6 +328,7 @@
 	"required": [
 		"boatData",
 		"portData",
+		"RouteAlerts",
 		"lastUpdate",
 		"serverVersion"
 	],

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import {
   fetchReferenceSailings,
   fetchReferenceScheduleRoutes,
   fetchScheduleCacheFlushDate,
+  fetchScheduleAlertData,
   fetchScheduleData,
   fetchTerminalBulletinData,
   fetchTerminalSailingSpaceData,
@@ -37,6 +38,7 @@ const app = express();
 const fetchInterval = 5000;
 const scheduleFetchInterval = 600000;
 const referenceScheduleFetchInterval = 86400000;
+const scheduleAlertFetchInterval = 600000;
 const terminalBulletinFetchInterval = 600000;
 const terminalSailingSpaceFetchInterval = 5000;
 const appVersion = process.env.npm_package_version;
@@ -48,6 +50,8 @@ let scheduleFetchInFlight = false;
 let latestReferenceSchedules = null;
 let latestReferenceScheduleCacheFlushDate = null;
 let referenceScheduleFetchInFlight = false;
+let latestScheduleAlertData = null;
+let scheduleAlertFetchInFlight = false;
 let latestTerminalBulletinData = null;
 let terminalBulletinFetchInFlight = false;
 let latestTerminalSailingSpaceData = null;
@@ -55,6 +59,7 @@ let terminalSailingSpaceFetchInFlight = false;
 
 function filterDeviceRouteData(routeData, includeScheduleList = false) {
   const filteredRouteData = JSON.parse(JSON.stringify(routeData));
+  delete filteredRouteData.RouteAlerts;
   for (const boatKey in filteredRouteData.boatData) {
     delete filteredRouteData.boatData[boatKey].CrossingTimeAverage;
     delete filteredRouteData.boatData[boatKey].StopTimerAverage;
@@ -819,6 +824,22 @@ const fetchTerminalBulletinDataForPorts = () => {
       });
 };
 
+const fetchScheduleAlertDataForRoutes = () => {
+  if (scheduleAlertFetchInFlight) {
+    return;
+  }
+
+  scheduleAlertFetchInFlight = true;
+  fetchScheduleAlertData()
+      .then((scheduleAlertData) => {
+        latestScheduleAlertData = scheduleAlertData;
+      })
+      .catch((error) => logger.error(`WSDOT schedule alerts are returning: ${error}`))
+      .finally(() => {
+        scheduleAlertFetchInFlight = false;
+      });
+};
+
 const fetchTerminalSailingSpaceDataForPorts = () => {
   if (terminalSailingSpaceFetchInFlight) {
     return;
@@ -847,6 +868,7 @@ const fetchAndProcessData = () => {
         const ferryTempoData = FerryTempo.processFerryData(
             vesselData,
             latestScheduleData,
+            latestScheduleAlertData,
             latestTerminalBulletinData,
             latestTerminalSailingSpaceData,
         );
@@ -885,6 +907,10 @@ setInterval(fetchReferenceScheduleDataForRoutes, referenceScheduleFetchInterval)
 logger.info(`Fetching terminal bulletin data every ${terminalBulletinFetchInterval / 1000} seconds.`);
 fetchTerminalBulletinDataForPorts();
 setInterval(fetchTerminalBulletinDataForPorts, terminalBulletinFetchInterval);
+
+logger.info(`Fetching schedule alert data every ${scheduleAlertFetchInterval / 1000} seconds.`);
+fetchScheduleAlertDataForRoutes();
+setInterval(fetchScheduleAlertDataForRoutes, scheduleAlertFetchInterval);
 
 logger.info(`Fetching terminal sailing space data every ${terminalSailingSpaceFetchInterval / 1000} seconds.`);
 fetchTerminalSailingSpaceDataForPorts();

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -119,9 +119,76 @@ function decodeBasicHtmlEntities(value) {
 }
 
 function getPlainTextFromHtml(value) {
-  return decodeBasicHtmlEntities(value.replace(/<[^>]*>/g, ' '))
+  return decodeBasicHtmlEntities(String(value || '').replace(/<[^>]*>/g, ' '))
       .replace(/\s+/g, ' ')
       .trim();
+}
+
+function normalizeAlertText(value) {
+  return String(value || '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+}
+
+function getAlertKey(alert) {
+  return `${normalizeAlertText(alert.Title)}|${normalizeAlertText(alert.Text)}`;
+}
+
+function addRouteAlert(routeData, alert) {
+  if (!alert.Title && !alert.Text) {
+    return;
+  }
+
+  routeData.RouteAlerts = routeData.RouteAlerts || [];
+  const alertKey = getAlertKey(alert);
+  const existingKeys = new Set(routeData.RouteAlerts.map(getAlertKey));
+  if (!existingKeys.has(alertKey)) {
+    routeData.RouteAlerts.push(alert);
+  }
+}
+
+function getNormalizedTerminalBulletin(bulletin) {
+  return {
+    Title: bulletin.BulletinTitle || '',
+    Text: getPlainTextFromHtml(bulletin.BulletinText || ''),
+    Html: bulletin.BulletinText || '',
+    SortSeq: bulletin.BulletinSortSeq ?? null,
+    LastUpdated: getEpochSecondsFromWSDOT(bulletin.BulletinLastUpdated),
+  };
+}
+
+function liftDuplicateTerminalAlerts(routeData) {
+  const westPort = routeData.portData.portWN;
+  const eastPort = routeData.portData.portES;
+  const westAlerts = westPort.TerminalAlerts || [];
+  const eastAlerts = eastPort.TerminalAlerts || [];
+  const eastAlertsByKey = Object.fromEntries(eastAlerts.map((alert) => [getAlertKey(alert), alert]));
+  const duplicateKeys = new Set(
+      westAlerts
+          .map(getAlertKey)
+          .filter((alertKey) => alertKey !== '|' && eastAlertsByKey[alertKey]),
+  );
+
+  if (duplicateKeys.size === 0) {
+    return;
+  }
+
+  for (const alert of westAlerts) {
+    const alertKey = getAlertKey(alert);
+    if (!duplicateKeys.has(alertKey)) {
+      continue;
+    }
+
+    addRouteAlert(routeData, {
+      ...alert,
+      Source: 'TerminalBulletin',
+      TerminalIDs: [westPort.TerminalID, eastPort.TerminalID],
+    });
+  }
+
+  westPort.TerminalAlerts = westAlerts.filter((alert) => !duplicateKeys.has(getAlertKey(alert)));
+  eastPort.TerminalAlerts = eastAlerts.filter((alert) => !duplicateKeys.has(getAlertKey(alert)));
 }
 
 function applyTerminalBulletinData(ferryTempoData, terminalBulletinData) {
@@ -138,14 +205,45 @@ function applyTerminalBulletinData(ferryTempoData, terminalBulletinData) {
       const portData = ferryTempoData[routeAbbreviation].portData[portKey];
       const terminalBulletin = bulletinsByTerminalId[portData.TerminalID];
       portData.TerminalAlerts = (terminalBulletin?.Bulletins || [])
-          .map((bulletin) => ({
-            Title: bulletin.BulletinTitle || '',
-            Text: getPlainTextFromHtml(bulletin.BulletinText || ''),
-            Html: bulletin.BulletinText || '',
-            SortSeq: bulletin.BulletinSortSeq ?? null,
-            LastUpdated: getEpochSecondsFromWSDOT(bulletin.BulletinLastUpdated),
-          }))
+          .map(getNormalizedTerminalBulletin)
           .sort((first, second) => (first.SortSeq ?? 0) - (second.SortSeq ?? 0));
+    }
+    liftDuplicateTerminalAlerts(ferryTempoData[routeAbbreviation]);
+  }
+}
+
+function applyScheduleAlertData(ferryTempoData, scheduleAlertData) {
+  if (!Array.isArray(scheduleAlertData)) {
+    return;
+  }
+
+  for (const routeAbbreviation in ferryTempoData) {
+    const routeData = ferryTempoData[routeAbbreviation];
+    const routeId = Number(routeData.routeID);
+    for (const scheduleAlert of scheduleAlertData) {
+      const affectedRouteIds = (scheduleAlert.AffectedRouteIDs || []).map(Number);
+      if (!affectedRouteIds.includes(routeId)) {
+        continue;
+      }
+
+      const title = scheduleAlert.AlertFullTitle || scheduleAlert.RouteAlertText || scheduleAlert.AlertDescription || '';
+      const html = scheduleAlert.BulletinText ||
+          scheduleAlert.HomepageAlertText ||
+          scheduleAlert.RouteAlertText ||
+          scheduleAlert.AlertDescription ||
+          title;
+
+      addRouteAlert(routeData, {
+        Title: title,
+        Text: getPlainTextFromHtml(html),
+        Html: html,
+        Source: 'ScheduleAlert',
+        PublishDate: getEpochSecondsFromWSDOT(scheduleAlert.PublishDate),
+        AffectedRouteIDs: affectedRouteIds,
+        RouteAlertFlag: Boolean(scheduleAlert.RouteAlertFlag),
+        BulletinFlag: Boolean(scheduleAlert.BulletinFlag),
+        CommunicationFlag: Boolean(scheduleAlert.CommunicationFlag),
+      });
     }
   }
 }
@@ -237,7 +335,13 @@ export default {
    * @param {object} vesselData - VesselData object containing updated WSDOT ferry data
    * @return {object} updated Ferry Tempo data object.
    */
-  processFerryData: (vesselData, scheduleData = null, terminalBulletinData = null, terminalSailingSpaceData = null) => {
+  processFerryData: (
+    vesselData,
+    scheduleData = null,
+    scheduleAlertData = null,
+    terminalBulletinData = null,
+    terminalSailingSpaceData = null,
+  ) => {
     // Create a fresh ferryTempoData object to fill
     const updatedFerryTempoData = JSON.parse(JSON.stringify(routeFTData));
 
@@ -591,6 +695,7 @@ export default {
         );
       }
     }
+    applyScheduleAlertData(updatedFerryTempoData, scheduleAlertData);
     applyTerminalBulletinData(updatedFerryTempoData, terminalBulletinData);
     applyTerminalSailingSpaceData(
         updatedFerryTempoData,

--- a/src/WSDOT.js
+++ b/src/WSDOT.js
@@ -47,6 +47,10 @@ export const fetchScheduleCacheFlushDate = async function() {
   return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/schedule/rest/cacheflushdate?apiaccesscode=${process.env.WSDOT_API_KEY}`);
 };
 
+export const fetchScheduleAlertData = async function() {
+  return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/schedule/rest/alerts?apiaccesscode=${process.env.WSDOT_API_KEY}`);
+};
+
 export const fetchTerminalBulletinData = async function() {
   return fetchWSDOTJson(`https://www.wsdot.wa.gov/ferries/api/terminals/rest/terminalbulletins?apiaccesscode=${process.env.WSDOT_API_KEY}`);
 };

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -437,7 +437,7 @@ describe('FerryTempo.processFerryData', () => {
         TimeStamp: wsdotDate(1710500100),
         ScheduledDeparture: wsdotDate(1710500600),
       }),
-    ], scheduleData, terminalBulletinData, terminalSailingSpaceData);
+    ], scheduleData, null, terminalBulletinData, terminalSailingSpaceData);
 
     expect(ferryTempoData['ed-king']['portData']['portES']['TerminalAlerts']).toEqual([
       {
@@ -457,5 +457,113 @@ describe('FerryTempo.processFerryData', () => {
       DriveUpSpaceCount: 42,
       MaxSpaceCount: 144,
     });
+  });
+
+  test('adds WSF schedule alerts to route data', () => {
+    const scheduleAlertData = [
+      {
+        AlertFullTitle: 'Fare changes begin Friday, May 1',
+        RouteAlertText: 'Fare changes begin Friday, May 1',
+        RouteAlertFlag: true,
+        BulletinFlag: true,
+        CommunicationFlag: false,
+        AffectedRouteIDs: [6, 7],
+        PublishDate: wsdotDate(1710600000),
+      },
+      {
+        AlertFullTitle: 'Other route alert',
+        RouteAlertText: 'Other route alert',
+        RouteAlertFlag: true,
+        BulletinFlag: true,
+        CommunicationFlag: false,
+        AffectedRouteIDs: [8],
+        PublishDate: wsdotDate(1710600000),
+      },
+    ];
+
+    const ferryTempoData = FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 10,
+        VesselName: 'Schedule Alert Boat',
+        Mmsi: 101010101,
+      }),
+    ], null, scheduleAlertData);
+
+    expect(ferryTempoData['ed-king'].RouteAlerts).toEqual([
+      {
+        Title: 'Fare changes begin Friday, May 1',
+        Text: 'Fare changes begin Friday, May 1',
+        Html: 'Fare changes begin Friday, May 1',
+        Source: 'ScheduleAlert',
+        PublishDate: 1710600000,
+        AffectedRouteIDs: [6, 7],
+        RouteAlertFlag: true,
+        BulletinFlag: true,
+        CommunicationFlag: false,
+      },
+    ]);
+  });
+
+  test('promotes duplicate terminal bulletins to route alerts', () => {
+    const terminalBulletinData = [
+      {
+        TerminalID: 8,
+        Bulletins: [
+          {
+            BulletinTitle: 'Elevator outage',
+            BulletinText: '<p>Elevator service is unavailable.</p>',
+            BulletinSortSeq: 2,
+            BulletinLastUpdated: wsdotDate(1710700000),
+          },
+          {
+            BulletinTitle: 'Edmonds only',
+            BulletinText: '<p>Use lane 3.</p>',
+            BulletinSortSeq: 3,
+            BulletinLastUpdated: wsdotDate(1710700100),
+          },
+        ],
+      },
+      {
+        TerminalID: 12,
+        Bulletins: [
+          {
+            BulletinTitle: 'Elevator outage',
+            BulletinText: '<p>Elevator service is unavailable.</p>',
+            BulletinSortSeq: 1,
+            BulletinLastUpdated: wsdotDate(1710700000),
+          },
+        ],
+      },
+    ];
+
+    const ferryTempoData = FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 11,
+        VesselName: 'Duplicate Alert Boat',
+        Mmsi: 111111110,
+      }),
+    ], null, null, terminalBulletinData);
+
+    expect(ferryTempoData['ed-king'].RouteAlerts).toEqual([
+      {
+        Title: 'Elevator outage',
+        Text: 'Elevator service is unavailable.',
+        Html: '<p>Elevator service is unavailable.</p>',
+        SortSeq: 1,
+        LastUpdated: 1710700000,
+        Source: 'TerminalBulletin',
+        TerminalIDs: [12, 8],
+      },
+    ]);
+    expect(ferryTempoData['ed-king']['portData']['portWN']['TerminalAlerts']).toEqual([]);
+    expect(ferryTempoData['ed-king']['portData']['portES']['TerminalAlerts']).toEqual([
+      {
+        Title: 'Edmonds only',
+        Text: 'Use lane 3.',
+        Html: '<p>Use lane 3.</p>',
+        SortSeq: 3,
+        LastUpdated: 1710700100,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Fetch WSF schedule alerts every 10 minutes and attach matching route/system messages to each route as RouteAlerts.

Promote identical terminal bulletins that appear on both route terminals into a single route-level alert while preserving terminal-specific bulletins under their port data.

Keep RouteAlerts out of cid hardware responses and add schema coverage plus tests for schedule alerts and duplicate terminal bulletin promotion.