### PR TITLE
Fix sailing day timezone rollover

### DIFF
--- a/src/StorageManager.js
+++ b/src/StorageManager.js
@@ -21,12 +21,17 @@ class StorageManager {
      */
     getSailingDayId(epochSeconds = Math.floor(Date.now() / 1000)) {
         const sailingDayStartHour = 3;
-        const eventDate = new Date(epochSeconds * 1000);
-        eventDate.setHours(eventDate.getHours() - sailingDayStartHour);
-        const year = eventDate.getFullYear();
-        const month = String(eventDate.getMonth() + 1).padStart(2, '0');
-        const day = String(eventDate.getDate()).padStart(2, '0');
-        return `${year}-${month}-${day}`;
+        const pacificTimeZone = 'America/Los_Angeles';
+        const adjustedDate = new Date((epochSeconds - (sailingDayStartHour * 60 * 60)) * 1000);
+
+        const dateParts = Object.fromEntries(new Intl.DateTimeFormat('en-US', {
+            timeZone: pacificTimeZone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        }).formatToParts(adjustedDate).map((datePart) => [datePart.type, datePart.value]));
+
+        return `${dateParts.year}-${dateParts.month}-${dateParts.day}`;
     }
 
     /**

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -46,6 +46,18 @@ describe('StorageManager', () => {
         expect(storageManager.getDelay(key, sailingDayEpoch + 86400)).toBeNull();
     });
 
+    test('getSailingDayId uses Pacific time instead of the server local timezone', () => {
+        expect(storageManager.getSailingDayId(1777431540)).toBe('2026-04-28');
+        expect(storageManager.getSailingDayId(1777431600)).toBe('2026-04-28');
+        expect(storageManager.getSailingDayId(1777456740)).toBe('2026-04-28');
+        expect(storageManager.getSailingDayId(1777456800)).toBe('2026-04-29');
+    });
+
+    test('getSailingDayId handles Pacific standard time before the 3am sailing-day reset', () => {
+        expect(storageManager.getSailingDayId(1768474740)).toBe('2026-01-14');
+        expect(storageManager.getSailingDayId(1768474800)).toBe('2026-01-15');
+    });
+
     test('sailing log annotates scheduled departures and resets by sailing day', () => {
         const key = 'ed-king:portES';
         const scheduleList = [sailingDayEpoch, sailingDayEpoch + 1800];


### PR DESCRIPTION
Calculate WSF sailing-day IDs in America/Los_Angeles instead of the server local timezone so Render/UTC does not roll schedules to the next trip date at 8 PM Pacific.

Keep the 3 AM sailing-day boundary, assemble YYYY-MM-DD explicitly from Intl format parts, and add daylight and standard time regression coverage around the Pacific rollover boundary.