### PR TITLE
Add route anomaly detector

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { Worker } from 'worker_threads';
 import { join } from 'path';
-import { compareAISData, getSailingDayId, getTimeFromEpochSeconds } from './Utils.js';
+import { compareAISData, getEpochSecondsFromWSDOT, getSailingDayId, getTimeFromEpochSeconds } from './Utils.js';
 import { getOpenWeatherData, processOpenWeatherData } from './OpenWeather.js';
 import validator from 'validator';  // for validating input
 
@@ -60,6 +60,116 @@ let latestTerminalLocationData = null;
 let terminalLocationFetchInFlight = false;
 let latestTerminalSailingSpaceData = null;
 let terminalSailingSpaceFetchInFlight = false;
+const vesselPositionState = new Map();
+const sailingAnomalies = [];
+const maxSailingAnomalies = 50;
+
+function getRouteAbbreviationFromVessel(vessel) {
+  const routeAbbreviation = vessel.OpRouteAbbrev?.[0];
+  if (routeAbbreviation && routeFTData[routeAbbreviation]) {
+    return routeAbbreviation;
+  }
+  return null;
+}
+
+function getVesselStateKey(vessel) {
+  return vessel.VesselID || vessel.Mmsi || vessel.VesselName;
+}
+
+function formatAnomalyTime(epochSeconds) {
+  if (!epochSeconds) {
+    return 'unknown';
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(new Date(epochSeconds * 1000));
+}
+
+function recordSailingAnomaly(anomaly) {
+  const duplicate = sailingAnomalies[0] &&
+      sailingAnomalies[0].vesselKey === anomaly.vesselKey &&
+      sailingAnomalies[0].routeAbbreviation === anomaly.routeAbbreviation &&
+      sailingAnomalies[0].oldPosition === anomaly.oldPosition &&
+      sailingAnomalies[0].newPosition === anomaly.newPosition;
+  if (duplicate) {
+    return;
+  }
+
+  sailingAnomalies.unshift(anomaly);
+  if (sailingAnomalies.length > maxSailingAnomalies) {
+    sailingAnomalies.length = maxSailingAnomalies;
+  }
+  logger.warn(
+      `Route anomaly: ${anomaly.vesselName} changed position on ${anomaly.routeAbbreviation} ` +
+      `from ${anomaly.oldPosition} to ${anomaly.newPosition}`,
+  );
+}
+
+function updateSailingAnomalies(vesselData) {
+  if (!Array.isArray(vesselData)) {
+    return;
+  }
+
+  for (const vessel of vesselData) {
+    const vesselKey = getVesselStateKey(vessel);
+    const routeAbbreviation = getRouteAbbreviationFromVessel(vessel);
+    const position = vessel.VesselPositionNum;
+    if (!vesselKey || !routeAbbreviation || position === null || position === undefined) {
+      continue;
+    }
+
+    const observedAt = getEpochSecondsFromWSDOT(vessel.TimeStamp) || Math.floor(Date.now() / 1000);
+    const nextState = {
+      routeAbbreviation,
+      position,
+      vesselName: vessel.VesselName,
+      departingTerminalName: vessel.DepartingTerminalName,
+      arrivingTerminalName: vessel.ArrivingTerminalName,
+      observedAt,
+    };
+    const previousState = vesselPositionState.get(vesselKey);
+    if (previousState &&
+        previousState.routeAbbreviation === routeAbbreviation &&
+        previousState.position !== position) {
+      recordSailingAnomaly({
+        observedAt,
+        observedAtDisplay: formatAnomalyTime(observedAt),
+        routeAbbreviation,
+        vesselKey,
+        vesselId: vessel.VesselID,
+        mmsi: vessel.Mmsi,
+        vesselName: vessel.VesselName,
+        oldPosition: previousState.position,
+        newPosition: position,
+        oldDepartingTerminalName: previousState.departingTerminalName,
+        oldArrivingTerminalName: previousState.arrivingTerminalName,
+        newDepartingTerminalName: vessel.DepartingTerminalName,
+        newArrivingTerminalName: vessel.ArrivingTerminalName,
+      });
+    }
+
+    vesselPositionState.set(vesselKey, nextState);
+  }
+}
+
+function getRouteAnomalySummary() {
+  const summary = {};
+  for (const routeAbbreviation of Object.keys(routeFTData)) {
+    const routeAnomalies = sailingAnomalies.filter((anomaly) => {
+      return anomaly.routeAbbreviation === routeAbbreviation;
+    });
+    summary[routeAbbreviation] = {
+      count: routeAnomalies.length,
+      latest: routeAnomalies[0] || null,
+    };
+  }
+  return summary;
+}
 
 function filterDeviceRouteData(routeData, includeScheduleList = false) {
   const filteredRouteData = JSON.parse(JSON.stringify(routeData));
@@ -358,7 +468,11 @@ app.set('view engine', 'pug');
 
 app.get('/', (request, response) => {
   const sanitizedVersion = validator.escape(appVersion);  // Escapes HTML special characters
-  response.render('index', { version: sanitizedVersion });
+  response.render('index', {
+    version: sanitizedVersion,
+    sailingAnomalies,
+    routeAnomalySummary: getRouteAnomalySummary(),
+  });
 });
 
 // Debug route for debugging and user-friendly routing. But limit results to avoid overloading memory
@@ -890,6 +1004,7 @@ const fetchAndProcessData = () => {
 
   fetchVesselData()
       .then((vesselData) => {
+        updateSailingAnomalies(vesselData);
         const ferryTempoData = FerryTempo.processFerryData(
             vesselData,
             latestScheduleData,

--- a/views/index.pug
+++ b/views/index.pug
@@ -14,6 +14,13 @@ html(lang='en')
             table tr td {
                 vertical-align:top;
             }
+            .anomaly {
+                color: #d97706;
+                font-weight: 700;
+            }
+            .muted {
+                color: #6b7280;
+            }
     body(class="container")
         header
             h1 Ferry Tempo Server v#{version} (#[a(href="https://github.com/FerryTempo/FTServer") github])
@@ -37,28 +44,78 @@ html(lang='en')
                 ul 
                     li
                         a(href="/progress?routeId=pt-cou&direction=WN&lat=48.159062&long=-122.672667" class="contrast") route & progress test
+                    li
+                        if routeAnomalySummary['pt-cou'].count
+                            a(href="#route-anomalies" class="anomaly") Route anomalies: #{routeAnomalySummary['pt-cou'].count}
+                        else
+                            span(class="muted") Route anomalies: none
             li
                 a(href="/api/v1/route/muk-cl" class="contrast") muk-cl data
                 ul 
                     li
                         a(href="/progress?routeId=muk-cl&direction=WN&lat=47.950761&long=-122.297106" class="contrast") route & progress test
+                    li
+                        if routeAnomalySummary['muk-cl'].count
+                            a(href="#route-anomalies" class="anomaly") Route anomalies: #{routeAnomalySummary['muk-cl'].count}
+                        else
+                            span(class="muted") Route anomalies: none
             li
                 a(href="/api/v1/route/ed-king" class="contrast") ed-king data
                 ul 
                     li
                         a(href="/progress?routeId=ed-king&direction=WN&lat=47.813343&long=-122.385422" class="contrast") route & progress test
+                    li
+                        if routeAnomalySummary['ed-king'].count
+                            a(href="#route-anomalies" class="anomaly") Route anomalies: #{routeAnomalySummary['ed-king'].count}
+                        else
+                            span(class="muted") Route anomalies: none
             li
                 a(href="/api/v1/route/sea-bi" class="contrast") sea-bi data
                 ul 
                     li
                         a(href="/progress?routeId=sea-bi&direction=WN&lat=47.602824&long=-122.339544" class="contrast") route & progress test
+                    li
+                        if routeAnomalySummary['sea-bi'].count
+                            a(href="#route-anomalies" class="anomaly") Route anomalies: #{routeAnomalySummary['sea-bi'].count}
+                        else
+                            span(class="muted") Route anomalies: none
             li
                 a(href="/api/v1/route/sea-br" class="contrast") sea-br data
                 ul 
                     li
                         a(href="/progress?routeId=sea-br&direction=WN&lat=47.602824&long=-122.339544" class="contrast") route & progress test
+                    li
+                        if routeAnomalySummary['sea-br'].count
+                            a(href="#route-anomalies" class="anomaly") Route anomalies: #{routeAnomalySummary['sea-br'].count}
+                        else
+                            span(class="muted") Route anomalies: none
             li
                 a(href="/api/v1/route/pd-tal" class="contrast") pd-tal data
                 ul
                     li
                         a(href="/progress?routeId=pd-tal&direction=WN&lat=47.306651&long=-122.514149" class="contrast") route & progress test
+                    li
+                        if routeAnomalySummary['pd-tal'].count
+                            a(href="#route-anomalies" class="anomaly") Route anomalies: #{routeAnomalySummary['pd-tal'].count}
+                        else
+                            span(class="muted") Route anomalies: none
+        h2(id="route-anomalies") Route Anomalies
+        if sailingAnomalies.length
+            table
+                thead
+                    tr
+                        th Time
+                        th Route
+                        th Vessel
+                        th Position
+                        th Terminals
+                tbody
+                    each anomaly in sailingAnomalies
+                        tr
+                            td= anomaly.observedAtDisplay
+                            td= anomaly.routeAbbreviation
+                            td #{anomaly.vesselName} (#{anomaly.vesselId || anomaly.mmsi || anomaly.vesselKey})
+                            td #{anomaly.oldPosition} → #{anomaly.newPosition}
+                            td #{anomaly.oldDepartingTerminalName || '?'} → #{anomaly.oldArrivingTerminalName || '?'} / #{anomaly.newDepartingTerminalName || '?'} → #{anomaly.newArrivingTerminalName || '?'}
+        else
+            p(class="muted") No route position anomalies observed since server start.


### PR DESCRIPTION
Track live WSF vessel position assignments in memory and record a route anomaly when the same vessel changes VesselPositionNum while remaining on the same route. Keep the latest anomalies capped in memory, log detections for server-side learning, and surface per-route anomaly status plus a details table on the server homepage without adding anything to route JSON or hardware payloads.