### PR TITLE
Tidy port diagnostic and vehicle fields

### DIFF
--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -378,18 +378,26 @@ function applyTerminalSailingSpaceData(ferryTempoData, terminalSailingSpaceData,
       portData.VehicleSpaces = {
         Departure: vehicleSpace.departureTime,
         IsCancelled: vehicleSpace.departureSpace.IsCancelled,
-        VesselID: vehicleSpace.departureSpace.VesselID,
-        VesselName: vehicleSpace.departureSpace.VesselName,
-        ArrivingTerminalID: vehicleSpace.arrivalSpace.TerminalID,
-        ArrivingTerminalName: vehicleSpace.arrivalSpace.TerminalName,
         DisplayDriveUpSpace: vehicleSpace.arrivalSpace.DisplayDriveUpSpace,
         DriveUpSpaceCount: vehicleSpace.arrivalSpace.DriveUpSpaceCount,
-        DriveUpSpaceHexColor: vehicleSpace.arrivalSpace.DriveUpSpaceHexColor,
-        DisplayReservableSpace: vehicleSpace.arrivalSpace.DisplayReservableSpace,
-        ReservableSpaceCount: vehicleSpace.arrivalSpace.ReservableSpaceCount,
-        ReservableSpaceHexColor: vehicleSpace.arrivalSpace.ReservableSpaceHexColor,
         MaxSpaceCount: vehicleSpace.arrivalSpace.MaxSpaceCount ?? vehicleSpace.departureSpace.MaxSpaceCount,
       };
+    }
+  }
+}
+
+function movePortDiagnosticFieldsToBottom(ferryTempoData) {
+  for (const routeAbbreviation in ferryTempoData) {
+    for (const portKey of ['portWN', 'portES']) {
+      const portData = ferryTempoData[routeAbbreviation].portData[portKey];
+      const terminalAlerts = portData.TerminalAlerts;
+      const portSailingLog = portData.PortSailingLog;
+      delete portData.TerminalAlerts;
+      delete portData.PortSailingLog;
+      if (terminalAlerts !== undefined) {
+        portData.TerminalAlerts = terminalAlerts;
+      }
+      portData.PortSailingLog = portSailingLog;
     }
   }
 }
@@ -814,6 +822,7 @@ export default {
         terminalSailingSpaceData,
         latestEventTime || getCurrentEpochSeconds(),
     );
+    movePortDiagnosticFieldsToBottom(updatedFerryTempoData);
 
     return updatedFerryTempoData;
   },

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -594,12 +594,17 @@ describe('FerryTempo.processFerryData', () => {
     expect(ferryTempoData['ed-king']['portData']['portES']['VehicleSpacesRemaining']).toBe(42);
     expect(ferryTempoData['ed-king']['portData']['portES']['VehicleSpaces']).toMatchObject({
       Departure: 1710500600,
-      VesselID: 1,
-      VesselName: 'Test Boat',
-      ArrivingTerminalID: 12,
+      IsCancelled: false,
+      DisplayDriveUpSpace: true,
       DriveUpSpaceCount: 42,
       MaxSpaceCount: 144,
     });
+    expect(ferryTempoData['ed-king']['portData']['portES']['VehicleSpaces']).not.toHaveProperty('VesselID');
+    expect(ferryTempoData['ed-king']['portData']['portES']['VehicleSpaces']).not.toHaveProperty('DriveUpSpaceHexColor');
+    expect(Object.keys(ferryTempoData['ed-king']['portData']['portES']).slice(-2)).toEqual([
+      'TerminalAlerts',
+      'PortSailingLog',
+    ]);
   });
 
   test('adds WSF schedule alerts to route data', () => {


### PR DESCRIPTION
Move TerminalAlerts and PortSailingLog to the bottom of each port object after all port enrichments run, keeping PortSailingLog last for readability. Trim VehicleSpaces to the app-useful fields only: Departure, IsCancelled, DisplayDriveUpSpace, DriveUpSpaceCount, and MaxSpaceCount, omitting redundant vessel, arrival-terminal, color, and reservable-space metadata. Update tests to lock the field order and slimmer vehicle payload.