### PR TITLE
Add notification subscription scaffold

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,10 @@ import { join } from 'path';
 import { compareAISData, getEpochSecondsFromWSDOT, getSailingDayId, getTimeFromEpochSeconds } from './Utils.js';
 import { getOpenWeatherData, processOpenWeatherData } from './OpenWeather.js';
 import validator from 'validator';  // for validating input
+import NotificationStore from './notifications/NotificationStore.js';
+import NotificationEvaluator from './notifications/NotificationEvaluator.js';
+import ApnsClient from './notifications/ApnsClient.js';
+import { createNotificationRouter } from './notifications/NotificationRoutes.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -45,6 +49,12 @@ const terminalLocationFetchInterval = 86400000;
 const terminalSailingSpaceFetchInterval = 5000;
 const appVersion = process.env.npm_package_version;
 const logger = new Logger();
+const notificationStore = new NotificationStore();
+const notificationEvaluator = new NotificationEvaluator(
+    notificationStore,
+    new ApnsClient(logger),
+    logger,
+);
 let latestAisData = null;
 let latestScheduleData = null;
 let latestScheduleTripDate = null;
@@ -462,6 +472,7 @@ function summarizeUpdateChecks(updateChecks) {
 // Set up the Express app.
 app.use(express.json());
 app.set('view engine', 'pug');
+app.use('/api/v1/notifications', createNotificationRouter(notificationStore));
 
 app.get('/', (request, response) => {
   const sanitizedVersion = validator.escape(appVersion);  // Escapes HTML special characters
@@ -1009,6 +1020,8 @@ const fetchAndProcessData = () => {
             latestTerminalSailingSpaceData,
             latestTerminalLocationData,
         );
+        notificationEvaluator.process(ferryTempoData)
+            .catch((error) => logger.error(`Notification evaluation failed: ${error.message}`));
 
         // Create a row for the latest data.
         const insert = db.prepare(`

--- a/src/notifications/ApnsClient.js
+++ b/src/notifications/ApnsClient.js
@@ -1,0 +1,17 @@
+class ApnsClient {
+  constructor(logger) {
+    this.logger = logger;
+  }
+
+  async sendNotification(deviceToken, payload) {
+    if (!process.env.APNS_ENABLED || process.env.APNS_ENABLED === 'false') {
+      this.logger?.debug(`APNs disabled; would send notification ${JSON.stringify(payload)}`);
+      return { sent: false, disabled: true };
+    }
+
+    throw new Error('APNs delivery is not implemented yet.');
+  }
+}
+
+export default ApnsClient;
+

--- a/src/notifications/NotificationEvaluator.js
+++ b/src/notifications/NotificationEvaluator.js
@@ -1,0 +1,131 @@
+import {
+  getTriggerKey,
+  notificationRecurrences,
+  notificationTriggerTypes,
+} from './NotificationTypes.js';
+
+export function getScheduledDepartureTimeKey(epochSeconds) {
+  const dateParts = Object.fromEntries(new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(new Date(epochSeconds * 1000)).map((datePart) => [datePart.type, datePart.value]));
+
+  return `${dateParts.hour}:${dateParts.minute}`;
+}
+
+function getSailingKey(sailing) {
+  return [
+    sailing.routeId,
+    sailing.direction,
+    sailing.scheduledDeparture,
+  ].join(':');
+}
+
+function getTriggeredKeys(boat) {
+  const triggeredKeys = [];
+  if (boat.LeftDock && boat.AtDock === false) {
+    triggeredKeys.push(getTriggerKey(notificationTriggerTypes.departed));
+  }
+
+  if (Number.isFinite(boat.ArrivalTimeMinus) && boat.ArrivalTimeMinus > 0) {
+    for (const minutes of [30, 25, 20, 15, 10, 5]) {
+      if (boat.ArrivalTimeMinus <= minutes * 60) {
+        triggeredKeys.push(getTriggerKey(notificationTriggerTypes.eta, minutes));
+      }
+    }
+  }
+
+  return triggeredKeys;
+}
+
+class NotificationEvaluator {
+  constructor(store, apnsClient, logger) {
+    this.store = store;
+    this.apnsClient = apnsClient;
+    this.logger = logger;
+  }
+
+  async process(ferryTempoData, observedAt = Math.floor(Date.now() / 1000)) {
+    if (!ferryTempoData || typeof ferryTempoData !== 'object') {
+      return;
+    }
+
+    for (const routeId in ferryTempoData) {
+      const routeData = ferryTempoData[routeId];
+      const boatData = routeData?.boatData || {};
+      for (const boatId in boatData) {
+        await this.processBoat(routeId, boatData[boatId], observedAt);
+      }
+    }
+  }
+
+  async processBoat(routeId, boat, observedAt) {
+    if (!boat?.ScheduledDeparture || !boat.Direction) {
+      return;
+    }
+
+    const sailing = {
+      routeId,
+      direction: boat.Direction,
+      departingTerminalAbbrev: boat.DepartingTerminalAbbrev || '',
+      arrivingTerminalAbbrev: boat.ArrivingTerminalAbbrev || '',
+      scheduledDeparture: boat.ScheduledDeparture,
+      scheduledDepartureTimeKey: getScheduledDepartureTimeKey(boat.ScheduledDeparture),
+    };
+    const triggeredKeys = new Set(getTriggeredKeys(boat));
+    if (triggeredKeys.size === 0) {
+      return;
+    }
+
+    const subscriptions = this.store.getActiveSubscriptionsForSailing(sailing);
+    for (const subscription of subscriptions) {
+      const triggerKey = getTriggerKey(subscription.triggerType, subscription.triggerMinutes);
+      if (!triggeredKeys.has(triggerKey)) {
+        continue;
+      }
+
+      const dedupeKey = [
+        subscription.id,
+        getSailingKey(sailing),
+        triggerKey,
+      ].join(':');
+      const shouldSend = this.store.recordFiredNotification({
+        dedupeKey,
+        subscriptionId: subscription.id,
+        deviceId: subscription.deviceId,
+        routeId,
+        direction: boat.Direction,
+        scheduledDeparture: boat.ScheduledDeparture,
+        triggerKey,
+        firedAt: observedAt,
+      });
+
+      if (!shouldSend) {
+        continue;
+      }
+
+      await this.sendSubscriptionNotification(subscription, sailing, boat, triggerKey);
+    }
+  }
+
+  async sendSubscriptionNotification(subscription, sailing, boat, triggerKey) {
+    try {
+      await this.apnsClient.sendNotification(subscription.token, {
+        deviceId: subscription.deviceId,
+        routeId: sailing.routeId,
+        direction: sailing.direction,
+        scheduledDeparture: sailing.scheduledDeparture,
+        recurrence: subscription.recurrence || notificationRecurrences.once,
+        triggerKey,
+        vesselName: boat.VesselName || '',
+      });
+    } catch (error) {
+      this.logger?.error(`Notification delivery failed: ${error.message}`);
+    }
+  }
+}
+
+export default NotificationEvaluator;
+

--- a/src/notifications/NotificationRoutes.js
+++ b/src/notifications/NotificationRoutes.js
@@ -1,0 +1,135 @@
+import express from 'express';
+import validator from 'validator';
+import routeFTData from '../../data/RouteFTData.js';
+import {
+  allowedEtaMinutes,
+  notificationRecurrences,
+  notificationTriggerTypes,
+} from './NotificationTypes.js';
+import { getScheduledDepartureTimeKey } from './NotificationEvaluator.js';
+
+function cleanString(value) {
+  return validator.escape(`${value ?? ''}`.trim());
+}
+
+function parsePositiveInteger(value) {
+  const numberValue = Number(value);
+  if (!Number.isInteger(numberValue) || numberValue <= 0) {
+    return null;
+  }
+  return numberValue;
+}
+
+function validateSubscription(body) {
+  const routeId = cleanString(body.routeId);
+  const direction = cleanString(body.direction);
+  const triggerType = cleanString(body.triggerType);
+  const recurrence = cleanString(body.recurrence || notificationRecurrences.once);
+  const scheduledDeparture = parsePositiveInteger(body.scheduledDeparture);
+  const triggerMinutes = triggerType === notificationTriggerTypes.eta ?
+    parsePositiveInteger(body.triggerMinutes) :
+    null;
+
+  if (!routeFTData.hasOwnProperty(routeId)) {
+    return { error: 'Unknown routeId.' };
+  }
+  if (!['ES', 'WN'].includes(direction)) {
+    return { error: 'direction must be ES or WN.' };
+  }
+  if (!Object.values(notificationTriggerTypes).includes(triggerType)) {
+    return { error: 'Unsupported triggerType.' };
+  }
+  if (triggerType === notificationTriggerTypes.eta && !allowedEtaMinutes.includes(triggerMinutes)) {
+    return { error: 'triggerMinutes must be one of the supported ETA buckets.' };
+  }
+  if (!Object.values(notificationRecurrences).includes(recurrence)) {
+    return { error: 'recurrence must be once or daily.' };
+  }
+  if (!scheduledDeparture) {
+    return { error: 'scheduledDeparture must be an epoch timestamp in seconds.' };
+  }
+
+  return {
+    subscription: {
+      deviceId: cleanString(body.deviceId),
+      routeId,
+      direction,
+      departingTerminalAbbrev: cleanString(body.departingTerminalAbbrev),
+      arrivingTerminalAbbrev: cleanString(body.arrivingTerminalAbbrev),
+      scheduledDeparture,
+      scheduledDepartureTimeKey: getScheduledDepartureTimeKey(scheduledDeparture),
+      triggerType,
+      triggerMinutes,
+      recurrence,
+    },
+  };
+}
+
+export function createNotificationRouter(store) {
+  const router = express.Router();
+
+  router.post('/register-token', (req, res) => {
+    const deviceId = cleanString(req.body.deviceId);
+    const token = cleanString(req.body.token);
+    const platform = cleanString(req.body.platform || 'ios');
+    const environment = cleanString(req.body.environment || 'production');
+
+    if (!deviceId || !token) {
+      res.status(400).json({ error: 'deviceId and token are required.' });
+      return;
+    }
+    if (platform !== 'ios') {
+      res.status(400).json({ error: 'Only ios push tokens are supported.' });
+      return;
+    }
+    if (!['sandbox', 'production'].includes(environment)) {
+      res.status(400).json({ error: 'environment must be sandbox or production.' });
+      return;
+    }
+
+    store.upsertPushToken({
+      deviceId,
+      token,
+      platform,
+      environment,
+      appVersion: cleanString(req.body.appVersion),
+    });
+    res.status(204).end();
+  });
+
+  router.post('/subscriptions', (req, res) => {
+    const { subscription, error } = validateSubscription(req.body);
+    if (error) {
+      res.status(400).json({ error });
+      return;
+    }
+    if (!subscription.deviceId) {
+      res.status(400).json({ error: 'deviceId is required.' });
+      return;
+    }
+
+    res.status(201).json(store.createSubscription(subscription));
+  });
+
+  router.get('/subscriptions/:deviceId', (req, res) => {
+    res.json(store.getSubscriptionsForDevice(cleanString(req.params.deviceId)));
+  });
+
+  router.delete('/subscriptions/:subscriptionId', (req, res) => {
+    const subscriptionId = parsePositiveInteger(req.params.subscriptionId);
+    const deviceId = cleanString(req.query.deviceId);
+    if (!subscriptionId || !deviceId) {
+      res.status(400).json({ error: 'subscriptionId and deviceId are required.' });
+      return;
+    }
+
+    if (!store.deactivateSubscription(subscriptionId, deviceId)) {
+      res.status(404).json({ error: 'Subscription not found.' });
+      return;
+    }
+    res.status(204).end();
+  });
+
+  return router;
+}
+

--- a/src/notifications/NotificationStore.js
+++ b/src/notifications/NotificationStore.js
@@ -1,0 +1,228 @@
+import Database from 'better-sqlite3';
+
+class NotificationStore {
+  constructor(dbPath = process.env.NOTIFICATION_DB_PATH || 'data/notifications.sqlite') {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initialize();
+  }
+
+  initialize() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS PushTokens (
+        id INTEGER PRIMARY KEY,
+        deviceId TEXT NOT NULL UNIQUE,
+        platform TEXT NOT NULL,
+        token TEXT NOT NULL,
+        environment TEXT NOT NULL,
+        appVersion TEXT,
+        disabled INTEGER NOT NULL DEFAULT 0,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS NotificationSubscriptions (
+        id INTEGER PRIMARY KEY,
+        deviceId TEXT NOT NULL,
+        routeId TEXT NOT NULL,
+        direction TEXT NOT NULL,
+        departingTerminalAbbrev TEXT,
+        arrivingTerminalAbbrev TEXT,
+        scheduledDeparture INTEGER NOT NULL,
+        scheduledDepartureTimeKey TEXT NOT NULL,
+        triggerType TEXT NOT NULL,
+        triggerMinutes INTEGER,
+        recurrence TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 1,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_notification_subscriptions_active
+        ON NotificationSubscriptions(active, routeId, direction, scheduledDeparture);
+
+      CREATE INDEX IF NOT EXISTS idx_notification_subscriptions_daily
+        ON NotificationSubscriptions(active, routeId, direction, scheduledDepartureTimeKey);
+
+      CREATE TABLE IF NOT EXISTS FiredNotifications (
+        id INTEGER PRIMARY KEY,
+        dedupeKey TEXT NOT NULL UNIQUE,
+        subscriptionId INTEGER NOT NULL,
+        deviceId TEXT NOT NULL,
+        routeId TEXT NOT NULL,
+        direction TEXT NOT NULL,
+        scheduledDeparture INTEGER NOT NULL,
+        triggerKey TEXT NOT NULL,
+        firedAt INTEGER NOT NULL
+      );
+    `);
+  }
+
+  close() {
+    this.db.close();
+  }
+
+  upsertPushToken(tokenInfo) {
+    const now = Math.floor(Date.now() / 1000);
+    return this.db.prepare(`
+      INSERT INTO PushTokens (
+        deviceId,
+        platform,
+        token,
+        environment,
+        appVersion,
+        disabled,
+        createdAt,
+        updatedAt
+      ) VALUES (
+        @deviceId,
+        @platform,
+        @token,
+        @environment,
+        @appVersion,
+        0,
+        @now,
+        @now
+      )
+      ON CONFLICT(deviceId) DO UPDATE SET
+        platform = excluded.platform,
+        token = excluded.token,
+        environment = excluded.environment,
+        appVersion = excluded.appVersion,
+        disabled = 0,
+        updatedAt = excluded.updatedAt
+    `).run({
+      ...tokenInfo,
+      appVersion: tokenInfo.appVersion || '',
+      now,
+    });
+  }
+
+  createSubscription(subscription) {
+    const now = Math.floor(Date.now() / 1000);
+    const result = this.db.prepare(`
+      INSERT INTO NotificationSubscriptions (
+        deviceId,
+        routeId,
+        direction,
+        departingTerminalAbbrev,
+        arrivingTerminalAbbrev,
+        scheduledDeparture,
+        scheduledDepartureTimeKey,
+        triggerType,
+        triggerMinutes,
+        recurrence,
+        active,
+        createdAt,
+        updatedAt
+      ) VALUES (
+        @deviceId,
+        @routeId,
+        @direction,
+        @departingTerminalAbbrev,
+        @arrivingTerminalAbbrev,
+        @scheduledDeparture,
+        @scheduledDepartureTimeKey,
+        @triggerType,
+        @triggerMinutes,
+        @recurrence,
+        1,
+        @now,
+        @now
+      )
+    `).run({
+      ...subscription,
+      departingTerminalAbbrev: subscription.departingTerminalAbbrev || '',
+      arrivingTerminalAbbrev: subscription.arrivingTerminalAbbrev || '',
+      triggerMinutes: subscription.triggerMinutes ?? null,
+      now,
+    });
+
+    return this.getSubscription(result.lastInsertRowid);
+  }
+
+  getSubscription(subscriptionId) {
+    return this.db.prepare(`
+      SELECT *
+      FROM NotificationSubscriptions
+      WHERE id = ?
+    `).get(subscriptionId);
+  }
+
+  getSubscriptionsForDevice(deviceId) {
+    return this.db.prepare(`
+      SELECT *
+      FROM NotificationSubscriptions
+      WHERE deviceId = ? AND active = 1
+      ORDER BY scheduledDeparture, triggerType, triggerMinutes
+    `).all(deviceId);
+  }
+
+  deactivateSubscription(subscriptionId, deviceId) {
+    const result = this.db.prepare(`
+      UPDATE NotificationSubscriptions
+      SET active = 0, updatedAt = unixepoch()
+      WHERE id = ? AND deviceId = ?
+    `).run(subscriptionId, deviceId);
+    return result.changes > 0;
+  }
+
+  getActiveSubscriptionsForSailing(sailing) {
+    return this.db.prepare(`
+      SELECT subscriptions.*, tokens.token, tokens.environment
+      FROM NotificationSubscriptions subscriptions
+      JOIN PushTokens tokens ON tokens.deviceId = subscriptions.deviceId
+      WHERE subscriptions.active = 1
+        AND tokens.disabled = 0
+        AND subscriptions.routeId = @routeId
+        AND subscriptions.direction = @direction
+        AND (
+          (
+            subscriptions.recurrence = 'once'
+            AND subscriptions.scheduledDeparture = @scheduledDeparture
+          )
+          OR (
+            subscriptions.recurrence = 'daily'
+            AND subscriptions.scheduledDepartureTimeKey = @scheduledDepartureTimeKey
+          )
+        )
+    `).all(sailing);
+  }
+
+  recordFiredNotification(event) {
+    const result = this.db.prepare(`
+      INSERT OR IGNORE INTO FiredNotifications (
+        dedupeKey,
+        subscriptionId,
+        deviceId,
+        routeId,
+        direction,
+        scheduledDeparture,
+        triggerKey,
+        firedAt
+      ) VALUES (
+        @dedupeKey,
+        @subscriptionId,
+        @deviceId,
+        @routeId,
+        @direction,
+        @scheduledDeparture,
+        @triggerKey,
+        @firedAt
+      )
+    `).run(event);
+
+    return result.changes > 0;
+  }
+
+  markTokenDisabled(deviceId) {
+    this.db.prepare(`
+      UPDATE PushTokens
+      SET disabled = 1, updatedAt = unixepoch()
+      WHERE deviceId = ?
+    `).run(deviceId);
+  }
+}
+
+export default NotificationStore;
+

--- a/src/notifications/NotificationTypes.js
+++ b/src/notifications/NotificationTypes.js
@@ -1,0 +1,20 @@
+export const notificationRecurrences = Object.freeze({
+  once: 'once',
+  daily: 'daily',
+});
+
+export const notificationTriggerTypes = Object.freeze({
+  departed: 'departed',
+  eta: 'eta',
+});
+
+export const allowedEtaMinutes = Object.freeze([5, 10, 15, 20, 25, 30]);
+
+export function getTriggerKey(triggerType, triggerMinutes) {
+  if (triggerType === notificationTriggerTypes.departed) {
+    return notificationTriggerTypes.departed;
+  }
+
+  return `eta_${triggerMinutes}`;
+}
+

--- a/test/NotificationEvaluator.test.js
+++ b/test/NotificationEvaluator.test.js
@@ -1,0 +1,139 @@
+import NotificationStore from '../src/notifications/NotificationStore.js';
+import NotificationEvaluator, {
+  getScheduledDepartureTimeKey,
+} from '../src/notifications/NotificationEvaluator.js';
+import {
+  notificationRecurrences,
+  notificationTriggerTypes,
+} from '../src/notifications/NotificationTypes.js';
+
+function buildFerryTempoData(scheduledDeparture, overrides = {}) {
+  return {
+    'sea-bi': {
+      boatData: {
+        boat1: {
+          Direction: 'ES',
+          DepartingTerminalAbbrev: 'Bain',
+          ArrivingTerminalAbbrev: 'Sea',
+          ScheduledDeparture: scheduledDeparture,
+          LeftDock: scheduledDeparture + 120,
+          AtDock: false,
+          ArrivalTimeMinus: 600,
+          VesselName: 'Test Ferry',
+          ...overrides,
+        },
+      },
+    },
+  };
+}
+
+describe('NotificationEvaluator', () => {
+  let store;
+  let sentNotifications;
+  let evaluator;
+
+  beforeEach(() => {
+    store = new NotificationStore(':memory:');
+    sentNotifications = [];
+    evaluator = new NotificationEvaluator(store, {
+      sendNotification: async (token, payload) => {
+        sentNotifications.push({ token, payload });
+        return { sent: true };
+      },
+    });
+
+    store.upsertPushToken({
+      deviceId: 'device-1',
+      platform: 'ios',
+      token: 'apns-token',
+      environment: 'sandbox',
+    });
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  test('sends a once subscription only for the matching scheduled departure', async () => {
+    const scheduledDeparture = 1768500000;
+    store.createSubscription({
+      deviceId: 'device-1',
+      routeId: 'sea-bi',
+      direction: 'ES',
+      departingTerminalAbbrev: 'Bain',
+      arrivingTerminalAbbrev: 'Sea',
+      scheduledDeparture,
+      scheduledDepartureTimeKey: getScheduledDepartureTimeKey(scheduledDeparture),
+      triggerType: notificationTriggerTypes.departed,
+      triggerMinutes: null,
+      recurrence: notificationRecurrences.once,
+    });
+
+    await evaluator.process(buildFerryTempoData(scheduledDeparture + 600));
+    expect(sentNotifications).toHaveLength(0);
+
+    await evaluator.process(buildFerryTempoData(scheduledDeparture));
+    expect(sentNotifications).toHaveLength(1);
+    expect(sentNotifications[0].payload).toMatchObject({
+      routeId: 'sea-bi',
+      direction: 'ES',
+      scheduledDeparture,
+      triggerKey: 'departed',
+    });
+  });
+
+  test('daily subscriptions match the same Pacific scheduled departure time', async () => {
+    const scheduledDeparture = 1768500000;
+    const nextDayDeparture = scheduledDeparture + 86400;
+    store.createSubscription({
+      deviceId: 'device-1',
+      routeId: 'sea-bi',
+      direction: 'ES',
+      departingTerminalAbbrev: 'Bain',
+      arrivingTerminalAbbrev: 'Sea',
+      scheduledDeparture,
+      scheduledDepartureTimeKey: getScheduledDepartureTimeKey(scheduledDeparture),
+      triggerType: notificationTriggerTypes.eta,
+      triggerMinutes: 10,
+      recurrence: notificationRecurrences.daily,
+    });
+
+    expect(getScheduledDepartureTimeKey(nextDayDeparture)).toBe(getScheduledDepartureTimeKey(scheduledDeparture));
+
+    await evaluator.process(buildFerryTempoData(nextDayDeparture, {
+      LeftDock: nextDayDeparture + 120,
+      ArrivalTimeMinus: 600,
+    }));
+
+    expect(sentNotifications).toHaveLength(1);
+    expect(sentNotifications[0].payload).toMatchObject({
+      scheduledDeparture: nextDayDeparture,
+      recurrence: 'daily',
+      triggerKey: 'eta_10',
+    });
+  });
+
+  test('does not send duplicate notifications for the same subscription and sailing', async () => {
+    const scheduledDeparture = 1768500000;
+    store.createSubscription({
+      deviceId: 'device-1',
+      routeId: 'sea-bi',
+      direction: 'ES',
+      departingTerminalAbbrev: 'Bain',
+      arrivingTerminalAbbrev: 'Sea',
+      scheduledDeparture,
+      scheduledDepartureTimeKey: getScheduledDepartureTimeKey(scheduledDeparture),
+      triggerType: notificationTriggerTypes.eta,
+      triggerMinutes: 10,
+      recurrence: notificationRecurrences.once,
+    });
+
+    await evaluator.process(buildFerryTempoData(scheduledDeparture));
+    await evaluator.process(buildFerryTempoData(scheduledDeparture, {
+      ArrivalTimeMinus: 540,
+    }));
+
+    expect(sentNotifications).toHaveLength(1);
+  });
+});
+


### PR DESCRIPTION
Introduce isolated notification modules for persistent push tokens, scheduled-departure subscriptions, trigger evaluation, and APNs delivery stubbing. Wire the evaluator into the FerryTempo data loop and expose notification registration/subscription routes, with tests covering once, daily, and dedupe behavior.