### PR TITLE
Scope crossing averages by route

### DIFF
--- a/schemas/FerryTempo.schema.json
+++ b/schemas/FerryTempo.schema.json
@@ -198,7 +198,7 @@
 					"type": "integer"
 				},
 				"PortSailingLog": {
-					"description": "Scheduled departures for the current sailing day paired with observed departure delay, crossing time in seconds, vessel position, and a low-resolution crossing plot, or null when not yet observed.",
+					"description": "Scheduled departures for the current sailing day paired with observed departure delay, crossing time in seconds, and vessel position.",
 					"type": "array",
 					"items": {
 						"type": "array",
@@ -218,33 +218,10 @@
 							{
 								"description": "WSF vessel position number for the sailing, or null when the departure has not been observed.",
 								"type": ["integer", "null"]
-							},
-							{
-								"description": "Observed crossing plot points as [ProgressPercent, LatitudeScaled, LongitudeScaled], using latitude/longitude multiplied by 100000, or null when no points have been observed.",
-								"type": ["array", "null"],
-								"items": {
-									"type": "array",
-									"prefixItems": [
-										{
-											"description": "Crossing progress bucket, 0 through 100.",
-											"type": "integer"
-										},
-										{
-											"description": "Latitude multiplied by 100000 and rounded.",
-											"type": "integer"
-										},
-										{
-											"description": "Longitude multiplied by 100000 and rounded.",
-											"type": "integer"
-										}
-									],
-									"minItems": 3,
-									"maxItems": 3
-								}
 							}
 						],
-						"minItems": 5,
-						"maxItems": 5
+						"minItems": 4,
+						"maxItems": 4
 					}
 				}
 			},

--- a/src/FerryTempo.js
+++ b/src/FerryTempo.js
@@ -12,7 +12,6 @@ import {
   getAverage, 
   recordSailingCrossingTime,
   recordSailingDepartureDelay,
-  recordSailingPlotPoint,
   getSailingLog,
   getSailingDayId,
   getRouteFromTerminals 
@@ -36,6 +35,10 @@ const AVERAGE_METRICS = {
 
 function getAverageKey(metric, key) {
   return `${metric}:${key}`;
+}
+
+function getRouteVesselAverageKey(metric, routeAbbreviation, vesselName) {
+  return getAverageKey(metric, `${routeAbbreviation}:${vesselName}`);
 }
 
 function getPortDelayCacheKey(routeAbbreviation, portKey) {
@@ -592,7 +595,7 @@ export default {
         let portDelayAvg = getAverage(portKey, delayEventTime);
         const boatProgress = AtDock ? 0 : getProgress(routeData, currentLocation);
         let crossingTimeAvg = getAverage(
-          getAverageKey(AVERAGE_METRICS.crossingTime, VesselName),
+          getRouteVesselAverageKey(AVERAGE_METRICS.crossingTime, routeAbbreviation, VesselName),
           delayEventTime,
         );
         let boatStopTimerAvg = getAverage(
@@ -623,8 +626,9 @@ export default {
               departureCache.leftDock;
             const crossingTime = epochTimeStamp - departureTime;
             if (crossingTime >= 0) {
+              const crossingRouteAbbreviation = departureCache.routeAbbreviation || routeAbbreviation;
               crossingTimeAvg = updateAverage(
-                getAverageKey(AVERAGE_METRICS.crossingTime, VesselName),
+                getRouteVesselAverageKey(AVERAGE_METRICS.crossingTime, crossingRouteAbbreviation, VesselName),
                 crossingTime,
                 epochTimeStamp,
               );
@@ -633,14 +637,6 @@ export default {
                     departureCache.portDelayCacheKey,
                     departureCache.scheduledDeparture,
                     crossingTime,
-                    epochTimeStamp,
-                );
-                recordSailingPlotPoint(
-                    departureCache.portDelayCacheKey,
-                    departureCache.scheduledDeparture,
-                    100,
-                    Latitude,
-                    Longitude,
                     epochTimeStamp,
                 );
               }
@@ -659,14 +655,6 @@ export default {
                 epochScheduledDeparture,
                 boatDelay,
                 vesselPositionNumber,
-                delayEventTime,
-            );
-            recordSailingPlotPoint(
-                portDelayCacheKey,
-                epochScheduledDeparture,
-                Math.min(90, Math.max(0, Math.floor(boatProgress * 10) * 10)),
-                Latitude,
-                Longitude,
                 delayEventTime,
             );
           }
@@ -694,6 +682,7 @@ export default {
           if (epochLeftDock) {
             boatDepartureCache[VesselName] = {
               leftDock: epochLeftDock,
+              routeAbbreviation,
               scheduledDeparture: epochScheduledDeparture,
               portDelayCacheKey,
               vesselPosition: vesselPositionNumber,

--- a/src/StorageManager.js
+++ b/src/StorageManager.js
@@ -99,7 +99,6 @@ class StorageManager {
                 departureDelays: {},
                 crossingTimes: {},
                 vesselPositions: {},
-                crossingPlots: {},
             };
         }
 
@@ -123,50 +122,10 @@ class StorageManager {
                 departureDelays: {},
                 crossingTimes: {},
                 vesselPositions: {},
-                crossingPlots: {},
             };
         }
 
         this.sailingLogStorage[key].crossingTimes[scheduledDeparture] = crossingTime;
-    }
-
-    /**
-     * Record a low-resolution crossing plot point for a scheduled departure.
-     * @param key Identifier for the port log.
-     * @param scheduledDeparture Scheduled departure epoch seconds.
-     * @param progressPercent Crossing progress bucket from 0 to 100.
-     * @param latitude Vessel latitude.
-     * @param longitude Vessel longitude.
-     * @param epochSeconds Event time used to scope data to a WSF sailing day.
-     */
-    setSailingPlotPoint(key, scheduledDeparture, progressPercent, latitude, longitude, epochSeconds) {
-        if (!Number.isFinite(progressPercent) || !Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-            return;
-        }
-
-        const sailingDayId = this.getSailingDayId(epochSeconds);
-        this.clearStaleDelayData(sailingDayId);
-        if (!this.sailingLogStorage[key] || this.sailingLogStorage[key].sailingDayId !== sailingDayId) {
-            this.sailingLogStorage[key] = {
-                sailingDayId,
-                departureDelays: {},
-                crossingTimes: {},
-                vesselPositions: {},
-                crossingPlots: {},
-            };
-        }
-
-        const plot = this.sailingLogStorage[key].crossingPlots[scheduledDeparture] || [];
-        const existingPoint = plot.find((point) => point[0] === progressPercent);
-        if (!existingPoint) {
-            plot.push([
-                progressPercent,
-                Math.round(latitude * 100000),
-                Math.round(longitude * 100000),
-            ]);
-            plot.sort((first, second) => first[0] - second[0]);
-        }
-        this.sailingLogStorage[key].crossingPlots[scheduledDeparture] = plot;
     }
 
     getScheduledDeparture(scheduleEntry) {
@@ -179,7 +138,7 @@ class StorageManager {
 
     /**
      * Get the current sailing-day departure log for a port as
-     * [ScheduledDeparture, DepartureDelay, CrossingTime, VesselPosition, CrossingPlot] rows.
+     * [ScheduledDeparture, DepartureDelay, CrossingTime, VesselPosition] rows.
      * @param key Identifier for the port log.
      * @param scheduleList Scheduled departures for the port.
      * @param epochSeconds Event time used to scope data to a WSF sailing day.
@@ -200,11 +159,6 @@ class StorageManager {
             this.sailingLogStorage[key]?.sailingDayId === sailingDayId ?
             this.sailingLogStorage[key].vesselPositions || {} :
             {};
-        const crossingPlots =
-            this.sailingLogStorage[key]?.sailingDayId === sailingDayId ?
-            this.sailingLogStorage[key].crossingPlots || {} :
-            {};
-
         if (scheduleList.length > 0) {
             return scheduleList.map((scheduleEntry) => {
                 const scheduledDeparture = this.getScheduledDeparture(scheduleEntry);
@@ -216,7 +170,6 @@ class StorageManager {
                     vesselPositions.hasOwnProperty(scheduledDeparture) ?
                         vesselPositions[scheduledDeparture] :
                         scheduledVesselPosition,
-                    crossingPlots.hasOwnProperty(scheduledDeparture) ? crossingPlots[scheduledDeparture] : null,
                 ];
             });
         }
@@ -225,7 +178,6 @@ class StorageManager {
             ...Object.keys(departureDelays),
             ...Object.keys(crossingTimes),
             ...Object.keys(vesselPositions),
-            ...Object.keys(crossingPlots),
         ]);
 
         return Array.from(scheduledDepartures)
@@ -234,7 +186,6 @@ class StorageManager {
                 departureDelays.hasOwnProperty(scheduledDeparture) ? departureDelays[scheduledDeparture] : null,
                 crossingTimes.hasOwnProperty(scheduledDeparture) ? crossingTimes[scheduledDeparture] : null,
                 vesselPositions.hasOwnProperty(scheduledDeparture) ? vesselPositions[scheduledDeparture] : null,
-                crossingPlots.hasOwnProperty(scheduledDeparture) ? crossingPlots[scheduledDeparture] : null,
             ])
             .sort((first, second) => first[0] - second[0]);
     }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -318,33 +318,6 @@ export function recordSailingCrossingTime(
 }
 
 /**
- * Record a low-resolution crossing plot point for a scheduled departure.
- * @param key Port log identifier.
- * @param scheduledDeparture Scheduled departure epoch seconds.
- * @param progressPercent Crossing progress bucket from 0 to 100.
- * @param latitude Vessel latitude.
- * @param longitude Vessel longitude.
- * @param epochSeconds Event time used to scope data to a WSF sailing day.
- */
-export function recordSailingPlotPoint(
-    key,
-    scheduledDeparture,
-    progressPercent,
-    latitude,
-    longitude,
-    epochSeconds = getCurrentEpochSeconds(),
-) {
-  storage.setSailingPlotPoint(
-      key,
-      scheduledDeparture,
-      progressPercent,
-      latitude,
-      longitude,
-      epochSeconds,
-  );
-}
-
-/**
  * Get a port's current sailing-day departure log.
  * @param key Port log identifier.
  * @param scheduleList Scheduled departures for the port.

--- a/test/FerryTempo.test.js
+++ b/test/FerryTempo.test.js
@@ -245,6 +245,84 @@ describe('FerryTempo.processFerryData', () => {
     expect(arrivalCycle['ed-king']['boatData']['boat1']['CrossingTimeAverage']).toBe(480);
   });
 
+  test('keeps crossing averages scoped to route and vessel', () => {
+    const edWestPoint = routePositionData['ed-king'][0];
+    const edEastPoint = routePositionData['ed-king'][routePositionData['ed-king'].length - 1];
+    const seaBIPoint = routePositionData['sea-bi'][routePositionData['sea-bi'].length - 1];
+
+    FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 55,
+        VesselName: 'Route Scoped Average Boat',
+        Mmsi: 555000555,
+        Latitude: edEastPoint[0],
+        Longitude: edEastPoint[1],
+        AtDock: true,
+        LeftDock: null,
+        TimeStamp: wsdotDate(1710110000),
+        ScheduledDeparture: wsdotDate(1710110120),
+      }),
+    ]);
+
+    FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 55,
+        VesselName: 'Route Scoped Average Boat',
+        Mmsi: 555000555,
+        Latitude: edEastPoint[0],
+        Longitude: edEastPoint[1],
+        AtDock: false,
+        LeftDock: wsdotDate(1710110120),
+        Eta: wsdotDate(1710110600),
+        TimeStamp: wsdotDate(1710110130),
+        ScheduledDeparture: wsdotDate(1710110120),
+      }),
+    ]);
+
+    FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 55,
+        VesselName: 'Route Scoped Average Boat',
+        Mmsi: 555000555,
+        DepartingTerminalID: 12,
+        DepartingTerminalName: 'Kingston',
+        DepartingTerminalAbbrev: 'KIN',
+        ArrivingTerminalName: 'Edmonds',
+        ArrivingTerminalAbbrev: 'EDM',
+        Latitude: edWestPoint[0],
+        Longitude: edWestPoint[1],
+        AtDock: true,
+        LeftDock: null,
+        Eta: null,
+        TimeStamp: wsdotDate(1710110600),
+        ScheduledDeparture: wsdotDate(1710110900),
+      }),
+    ]);
+
+    const seaBICycle = FerryTempo.processFerryData([
+      buildVessel({
+        VesselID: 55,
+        VesselName: 'Route Scoped Average Boat',
+        Mmsi: 555000555,
+        DepartingTerminalID: 7,
+        DepartingTerminalName: 'Seattle',
+        DepartingTerminalAbbrev: 'P52',
+        ArrivingTerminalName: 'Bainbridge Island',
+        ArrivingTerminalAbbrev: 'BBI',
+        Latitude: seaBIPoint[0],
+        Longitude: seaBIPoint[1],
+        AtDock: false,
+        LeftDock: wsdotDate(1710111120),
+        Eta: wsdotDate(1710113100),
+        TimeStamp: wsdotDate(1710111130),
+        ScheduledDeparture: wsdotDate(1710111120),
+        OpRouteAbbrev: ['sea-bi'],
+      }),
+    ]);
+
+    expect(seaBICycle['sea-bi']['boatData']['boat1']['CrossingTimeAverage']).toBe(0);
+  });
+
   test('sets port ETA to the computed arrival clock time that matches ArrivalTimeMinus', () => {
     const eastPoint = routePositionData['ed-king'][routePositionData['ed-king'].length - 1];
 
@@ -326,12 +404,8 @@ describe('FerryTempo.processFerryData', () => {
         60,
         2000,
         1,
-        [
-          [0, Math.round(eastPoint[0] * 100000), Math.round(eastPoint[1] * 100000)],
-          [100, Math.round(westPoint[0] * 100000), Math.round(westPoint[1] * 100000)],
-        ],
       ],
-      [1710701800, null, null, null, null],
+      [1710701800, null, null, null],
     ]);
   });
 
@@ -371,14 +445,14 @@ describe('FerryTempo.processFerryData', () => {
     expect(ferryTempoData['ed-king']['portData']['portES']['PortScheduleList']).toBeUndefined();
     expect(ferryTempoData['ed-king']['portData']['portES']['PortScheduleAssignments']).toBeUndefined();
     expect(ferryTempoData['ed-king']['portData']['portES']['PortSailingLog']).toEqual([
-      [1710200000, null, null, 1, null],
-      [1710200600, null, null, 2, null],
+      [1710200000, null, null, 1],
+      [1710200600, null, null, 2],
     ]);
     expect(ferryTempoData['ed-king']['portData']['portES']['NextScheduledDeparture']).toBe(1710200600);
     expect(ferryTempoData['ed-king']['portData']['portWN']['PortScheduleList']).toBeUndefined();
     expect(ferryTempoData['ed-king']['portData']['portWN']['PortScheduleAssignments']).toBeUndefined();
     expect(ferryTempoData['ed-king']['portData']['portWN']['PortSailingLog']).toEqual([
-      [1710200300, null, null, null, null],
+      [1710200300, null, null, null],
     ]);
     expect(ferryTempoData['ed-king']['portData']['portWN']['NextScheduledDeparture']).toBe(1710200300);
   });
@@ -491,8 +565,8 @@ describe('FerryTempo.processFerryData', () => {
     expect(ferryTempoData['ed-king']['portData']['portES']['PortScheduleList']).toBeUndefined();
     expect(ferryTempoData['ed-king']['portData']['portES']['PortScheduleAssignments']).toBeUndefined();
     expect(ferryTempoData['ed-king']['portData']['portES']['PortSailingLog']).toEqual([
-      [1710410000, null, null, null, null],
-      [1710411800, null, null, null, null],
+      [1710410000, null, null, null],
+      [1710411800, null, null, null],
     ]);
     expect(ferryTempoData['ed-king']['portData']['portES']['NextScheduledDeparture']).toBe(1710410000);
   });

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -64,10 +64,7 @@ describe('StorageManager', () => {
 
         storageManager.setSailingDepartureDelay(key, sailingDayEpoch, 60, 1, sailingDayEpoch + 60);
         storageManager.setSailingDepartureDelay(key, sailingDayEpoch, 60, 1, sailingDayEpoch + 60);
-        storageManager.setSailingPlotPoint(key, sailingDayEpoch, 0, 47.1, -122.1, sailingDayEpoch + 60);
-        storageManager.setSailingPlotPoint(key, sailingDayEpoch, 10, 47.2, -122.2, sailingDayEpoch + 300);
         storageManager.setSailingCrossingTime(key, sailingDayEpoch, 1500, sailingDayEpoch + 1560);
-        storageManager.setSailingPlotPoint(key, sailingDayEpoch, 100, 47.3, -122.3, sailingDayEpoch + 1560);
 
         expect(storageManager.getSailingLog(key, scheduleList, sailingDayEpoch)).toEqual([
             [
@@ -75,17 +72,12 @@ describe('StorageManager', () => {
                 60,
                 1500,
                 1,
-                [
-                    [0, 4710000, -12210000],
-                    [10, 4720000, -12220000],
-                    [100, 4730000, -12230000],
-                ],
             ],
-            [sailingDayEpoch + 1800, null, null, 2, null],
+            [sailingDayEpoch + 1800, null, null, 2],
         ]);
         expect(storageManager.getSailingLog(key, scheduleList, sailingDayEpoch + 86400)).toEqual([
-            [sailingDayEpoch, null, null, 1, null],
-            [sailingDayEpoch + 1800, null, null, 2, null],
+            [sailingDayEpoch, null, null, 1],
+            [sailingDayEpoch + 1800, null, null, 2],
         ]);
     });
 });


### PR DESCRIPTION
Key crossing-time averages by route and vessel so vessels reassigned across routes do not carry incompatible same-day crossing durations into another route. Remove the low-resolution 10 percent crossing plot collection from PortSailingLog and update the schema/tests for the slimmer sailing-day log payload.