### PR TITLE
Fix APNs delivery handling

### DIFF
--- a/src/notifications/ApnsClient.js
+++ b/src/notifications/ApnsClient.js
@@ -25,13 +25,17 @@ class ApnsClient {
     this.cachedJwtIssuedAt = 0;
   }
 
-  async sendNotification(deviceToken, payload) {
+  async sendNotification(deviceToken, payload, options = {}) {
     if (!process.env.APNS_ENABLED || process.env.APNS_ENABLED === 'false') {
       this.logger?.debug(`APNs disabled; would send notification ${JSON.stringify(payload)}`);
       return { sent: false, disabled: true };
     }
 
-    const response = await this.sendApnsRequest(deviceToken, this.buildNotificationPayload(payload));
+    const response = await this.sendApnsRequest(
+        deviceToken,
+        this.buildNotificationPayload(payload),
+        options.environment,
+    );
     if (response.statusCode >= 200 && response.statusCode < 300) {
       return { sent: true };
     }
@@ -76,9 +80,11 @@ class ApnsClient {
     return 'Your ferry notification is ready.';
   }
 
-  sendApnsRequest(deviceToken, notificationPayload) {
+  sendApnsRequest(deviceToken, notificationPayload, environment) {
     return new Promise((resolve, reject) => {
-      const production = process.env.APNS_PRODUCTION === 'true';
+      const production = environment ?
+        environment === 'production' :
+        process.env.APNS_PRODUCTION === 'true';
       const host = production ? 'api.push.apple.com' : 'api.sandbox.push.apple.com';
       const client = http2.connect(`https://${host}`);
       const body = JSON.stringify(notificationPayload);

--- a/src/notifications/NotificationEvaluator.js
+++ b/src/notifications/NotificationEvaluator.js
@@ -106,13 +106,16 @@ class NotificationEvaluator {
         continue;
       }
 
-      await this.sendSubscriptionNotification(subscription, sailing, boat, triggerKey);
+      const delivered = await this.sendSubscriptionNotification(subscription, sailing, boat, triggerKey);
+      if (!delivered) {
+        this.store.removeFiredNotification(dedupeKey);
+      }
     }
   }
 
   async sendSubscriptionNotification(subscription, sailing, boat, triggerKey) {
     try {
-      await this.apnsClient.sendNotification(subscription.token, {
+      const result = await this.apnsClient.sendNotification(subscription.token, {
         deviceId: subscription.deviceId,
         routeId: sailing.routeId,
         direction: sailing.direction,
@@ -120,12 +123,24 @@ class NotificationEvaluator {
         recurrence: subscription.recurrence || notificationRecurrences.once,
         triggerKey,
         vesselName: boat.VesselName || '',
+      }, {
+        environment: subscription.environment,
       });
+
+      if (result?.invalidToken) {
+        this.store.markTokenDisabled(subscription.deviceId);
+        this.logger?.warn(
+            `Disabled APNs token for device ${subscription.deviceId}: ${result.reason}`,
+        );
+        return true;
+      }
+
+      return result?.sent === true;
     } catch (error) {
       this.logger?.error(`Notification delivery failed: ${error.message}`);
+      return false;
     }
   }
 }
 
 export default NotificationEvaluator;
-

--- a/src/notifications/NotificationStore.js
+++ b/src/notifications/NotificationStore.js
@@ -215,6 +215,13 @@ class NotificationStore {
     return result.changes > 0;
   }
 
+  removeFiredNotification(dedupeKey) {
+    this.db.prepare(`
+      DELETE FROM FiredNotifications
+      WHERE dedupeKey = ?
+    `).run(dedupeKey);
+  }
+
   markTokenDisabled(deviceId) {
     this.db.prepare(`
       UPDATE PushTokens
@@ -225,4 +232,3 @@ class NotificationStore {
 }
 
 export default NotificationStore;
-

--- a/test/NotificationEvaluator.test.js
+++ b/test/NotificationEvaluator.test.js
@@ -30,14 +30,17 @@ function buildFerryTempoData(scheduledDeparture, overrides = {}) {
 describe('NotificationEvaluator', () => {
   let store;
   let sentNotifications;
+  let sendOptions;
   let evaluator;
 
   beforeEach(() => {
     store = new NotificationStore(':memory:');
     sentNotifications = [];
+    sendOptions = [];
     evaluator = new NotificationEvaluator(store, {
-      sendNotification: async (token, payload) => {
+      sendNotification: async (token, payload, options) => {
         sentNotifications.push({ token, payload });
+        sendOptions.push(options);
         return { sent: true };
       },
     });
@@ -80,6 +83,7 @@ describe('NotificationEvaluator', () => {
       scheduledDeparture,
       triggerKey: 'departed',
     });
+    expect(sendOptions[0]).toEqual({ environment: 'sandbox' });
   });
 
   test('daily subscriptions match the same Pacific scheduled departure time', async () => {
@@ -135,5 +139,63 @@ describe('NotificationEvaluator', () => {
 
     expect(sentNotifications).toHaveLength(1);
   });
-});
 
+  test('disables tokens that APNs reports as invalid', async () => {
+    evaluator = new NotificationEvaluator(store, {
+      sendNotification: async () => ({ sent: false, invalidToken: true, reason: 'BadDeviceToken' }),
+    });
+    const scheduledDeparture = 1768500000;
+    store.createSubscription({
+      deviceId: 'device-1',
+      routeId: 'sea-bi',
+      direction: 'ES',
+      departingTerminalAbbrev: 'Bain',
+      arrivingTerminalAbbrev: 'Sea',
+      scheduledDeparture,
+      scheduledDepartureTimeKey: getScheduledDepartureTimeKey(scheduledDeparture),
+      triggerType: notificationTriggerTypes.departed,
+      triggerMinutes: null,
+      recurrence: notificationRecurrences.once,
+    });
+
+    await evaluator.process(buildFerryTempoData(scheduledDeparture));
+
+    const tokenRow = store.db.prepare(`
+      SELECT disabled
+      FROM PushTokens
+      WHERE deviceId = ?
+    `).get('device-1');
+    expect(tokenRow.disabled).toBe(1);
+  });
+
+  test('retries a notification when APNs delivery fails temporarily', async () => {
+    let attempts = 0;
+    evaluator = new NotificationEvaluator(store, {
+      sendNotification: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error('Provider token failed');
+        }
+        return { sent: true };
+      },
+    });
+    const scheduledDeparture = 1768500000;
+    store.createSubscription({
+      deviceId: 'device-1',
+      routeId: 'sea-bi',
+      direction: 'ES',
+      departingTerminalAbbrev: 'Bain',
+      arrivingTerminalAbbrev: 'Sea',
+      scheduledDeparture,
+      scheduledDepartureTimeKey: getScheduledDepartureTimeKey(scheduledDeparture),
+      triggerType: notificationTriggerTypes.departed,
+      triggerMinutes: null,
+      recurrence: notificationRecurrences.once,
+    });
+
+    await evaluator.process(buildFerryTempoData(scheduledDeparture));
+    await evaluator.process(buildFerryTempoData(scheduledDeparture));
+
+    expect(attempts).toBe(2);
+  });
+});


### PR DESCRIPTION
Route APNs sends through the stored token environment so sandbox and production tokens use the correct Apple endpoint. Retry transient delivery failures by clearing the fired marker, and disable tokens that APNs reports as invalid.