### PR TITLE
Update ws dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "pug": "^3.0.2",
         "validator": "^13.12.0",
         "winston": "^3.13.0",
-        "ws": "^8.18.0"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.17.0",
@@ -8456,9 +8456,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pug": "^3.0.2",
     "validator": "^13.12.0",
     "winston": "^3.13.0",
-    "ws": "^8.18.0"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",


### PR DESCRIPTION
Bump ws to ^8.21.0 so the installed package resolves to 8.21.0, addressing the Dependabot alert for ws memory disclosure and DoS advisories.

Verification: npm test